### PR TITLE
Add persistenceagent deployment patch to fix metrics read error. Fixes #392

### DIFF
--- a/kubeflow/apps/pipelines/kustomization.yaml
+++ b/kubeflow/apps/pipelines/kustomization.yaml
@@ -41,6 +41,7 @@ resources:
 - upstream/base/installs/multi-user
 patchesStrategicMerge:
 - patches/ml-pipeline-deployment-patch.yaml
+- patches/ml-pipeline-persistenceagent-deployment-patch.yaml
 - patches/ml-pipeline-ui-deployment-patch.yaml
 - patches/ml-pipeline-authorization-policy-patch.yaml
 - patches/workload-identity-binding.yaml

--- a/kubeflow/apps/pipelines/patches/ml-pipeline-persistenceagent-deployment-patch.yaml
+++ b/kubeflow/apps/pipelines/patches/ml-pipeline-persistenceagent-deployment-patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-persistenceagent
+spec:
+  template:
+    spec:
+      containers:
+      - name: ml-pipeline-persistenceagent
+        env:
+        - name: KUBEFLOW_USERID_HEADER
+          value: null
+          valueFrom:
+            configMapKeyRef:
+              name: kubeflow-config
+              key: userid-header
+        - name: KUBEFLOW_USERID_PREFIX
+          value: null
+          valueFrom:
+            configMapKeyRef:
+              name: kubeflow-config
+              key: userid-prefix


### PR DESCRIPTION
https://github.com/kubeflow/pipelines/pull/7819 add `KUBEFLOW_USERID_HEADER` and `KUBEFLOW_USERID_PREFIX` in upstream `persistenceagent` deployment config. 
Without this patch, the upstream config causes a mismatch of header and prefix choices between `api-server` and `persistenceagent`, which fails authorization check in `ReadArtifact`.

Fixes #392