### PR TITLE
Releasing GCP Kubeflow distribution v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 The Kubeflow on Google Cloud distribution versioning is following the versioning of [kubeflow/manifests](https://github.com/kubeflow/manifests).
 
-### v1.6.1-rc.0
+### v1.6.1
 
-* Upgrade MySQL version to 8.0 (#391)
+* Upgrade CloudSQL to MySQL 8.0 (#391)
 * Upgrade KFP to v2.0.0-alpha.5
 * Fix ASM bash issues (#389)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,26 @@
 
 The Kubeflow on Google Cloud distribution versioning is following the versioning of [kubeflow/manifests](https://github.com/kubeflow/manifests).
 
-### v1.6.0-rc.1
+### v1.6.1-rc.0
+
+* Upgrade MySQL version to 8.0 (#391)
+* Upgrade KFP to v2.0.0-alpha.5
+* Fix ASM bash issues (#389)
+
+### v1.6.0
 
 * Update CHANGELOG (#360)
+* Migrate deprecated API calls (#349)
 * Upgrade cert-manger to v1.5.0 (#372)
 * Upgrade knative to v1.2 (#373)
+* Upgrade ASM to v1.14 (#385)
+* Upgrade KFP to v2.0.0-alpha.4
 * Fix ASM/istio ingress gateway issue (#371)
-* Migrate deprecated API calls (#349)
+* Fix race condition in Kserve (#384)
+* Fix deployment flakiness (#386)
 * Remove deprecated KFServing (#375)
 * Remove deprecated cloud-endpoints-controller (#377)
+* Remove deprecated contrib/application
 
 ### v1.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The Kubeflow on Google Cloud distribution versioning is following the versioning
 ### v1.6.1
 
 * Upgrade CloudSQL to MySQL 8.0 (#391)
-* Upgrade KFP to v2.0.0-alpha.5
+* Upgrade KFP to v2.0.0-alpha.6
 * Fix ASM bash issues (#389)
 
 ### v1.6.0

--- a/kubeflow/apps/pipelines/kustomization.yaml
+++ b/kubeflow/apps/pipelines/kustomization.yaml
@@ -21,8 +21,9 @@ resources:
 - upstream/third-party/minio/options/istio
 # ==== Database ====
 # recommended, use cloud sql for easier maintenance
+# CloudSQL was upgrade to MySQL 8.0 in Kubeflow 1.6.1 release
 - cloudsql/proxy
-# Altenatively, use in-cluster mysql by:
+# Alternatively, use in-cluster mysql 5.7 by:
 # 1. remove gcs/pipeline-install-config-patch.yaml from patchesStrategicMerge
 # 2. remove ../cloudsql/cnrm from ./cnrm/kustomization.yaml
 # 3. comment cloudsql/proxy above, and uncomment the following line

--- a/kubeflow/apps/pipelines/kustomization.yaml
+++ b/kubeflow/apps/pipelines/kustomization.yaml
@@ -23,7 +23,7 @@ resources:
 # recommended, use cloud sql for easier maintenance
 # CloudSQL was upgrade to MySQL 8.0 in Kubeflow 1.6.1 release
 - cloudsql/proxy
-# Alternatively, use in-cluster mysql 5.7 by:
+# Alternatively, use in-cluster mysql by:
 # 1. remove gcs/pipeline-install-config-patch.yaml from patchesStrategicMerge
 # 2. remove ../cloudsql/cnrm from ./cnrm/kustomization.yaml
 # 3. comment cloudsql/proxy above, and uncomment the following line

--- a/kubeflow/asm/Makefile
+++ b/kubeflow/asm/Makefile
@@ -43,7 +43,7 @@ install-asm: download-asmcli download-asm-package
 	--project_id $(PROJECT) \
 	--cluster_name $(NAME) \
 	--cluster_location $(LOCATION) \
-	--output_dir $(UPSTREAM) \
+	--output_dir ./package \
 	--enable_all \
 	--ca mesh_ca \
 	--custom_overlay ./package/asm/istio/options/iap-operator.yaml \
@@ -63,7 +63,7 @@ asmcli-validate:
 	--project_id $(PROJECT) \
 	--cluster_name $(NAME) \
 	--cluster_location $(LOCATION) \
-	--output_dir $(UPSTREAM) \
+	--output_dir ./package \
 	--ca mesh_ca \
 	--custom_overlay ./package/asm/istio/options/iap-operator.yaml \
 	--custom_overlay ./options/ingressgateway-iap.yaml \

--- a/kubeflow/asm/Makefile
+++ b/kubeflow/asm/Makefile
@@ -72,7 +72,7 @@ asmcli-validate:
 
 .PHONY: asmcli-precheck
 asmcli-precheck:
-	pushd ${UPSTREAM} && ./istioctl experimental precheck && popd
+	pushd ./package && ./istioctl experimental precheck && popd
 # Note about install gateways
 # https://cloud.google.com/service-mesh/docs/unified-install/install#install_gateways
 

--- a/kubeflow/asm/Makefile
+++ b/kubeflow/asm/Makefile
@@ -21,7 +21,7 @@ NAME=$(shell $(YQ) e '.data.name' kptconfig/kpt-setter-config.yaml)
 PROJECT=$(shell $(YQ) e '.data."gcloud.core.project"' kptconfig/kpt-setter-config.yaml)
 LOCATION=$(shell $(YQ) e '.data.location' kptconfig/kpt-setter-config.yaml)
 
-UPSTREAM=upstream
+UPSTREAM=package
 
 .PHONY: download-asmcli
 download-asmcli: 
@@ -33,9 +33,9 @@ download-asm-package:
 	rm -rf asm.tar.gz
 	curl -LJ https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/archive/refs/tags/$(ASM_PACKAGE_VERSION).tar.gz -o asm.tar.gz 
 	
-	rm -rf ./package
-	mkdir package
-	tar -xf asm.tar.gz --strip-components=1 -C package 
+	rm -rf $(UPSTREAM)
+	mkdir $(UPSTREAM)
+	tar -xf asm.tar.gz --strip-components=1 -C $(UPSTREAM) 
 
 .PHONY: install-asm
 install-asm: download-asmcli download-asm-package
@@ -43,10 +43,10 @@ install-asm: download-asmcli download-asm-package
 	--project_id $(PROJECT) \
 	--cluster_name $(NAME) \
 	--cluster_location $(LOCATION) \
-	--output_dir ./package \
+	--output_dir $(UPSTREAM) \
 	--enable_all \
 	--ca mesh_ca \
-	--custom_overlay ./package/asm/istio/options/iap-operator.yaml \
+	--custom_overlay $(UPSTREAM)/asm/istio/options/iap-operator.yaml \
 	--custom_overlay ./options/ingressgateway-iap.yaml \
 	--option legacy-default-ingressgateway \
 	--verbose
@@ -63,16 +63,16 @@ asmcli-validate:
 	--project_id $(PROJECT) \
 	--cluster_name $(NAME) \
 	--cluster_location $(LOCATION) \
-	--output_dir ./package \
+	--output_dir $(UPSTREAM) \
 	--ca mesh_ca \
-	--custom_overlay ./package/asm/istio/options/iap-operator.yaml \
+	--custom_overlay $(UPSTREAM)/asm/istio/options/iap-operator.yaml \
 	--custom_overlay ./options/ingressgateway-iap.yaml \
 	--option legacy-default-ingressgateway \
 	--verbose
 
 .PHONY: asmcli-precheck
 asmcli-precheck:
-	pushd ./package && ./istioctl experimental precheck && popd
+	pushd $(UPSTREAM) && ./istioctl experimental precheck && popd
 # Note about install gateways
 # https://cloud.google.com/service-mesh/docs/unified-install/install#install_gateways
 

--- a/kubeflow/asm/Makefile
+++ b/kubeflow/asm/Makefile
@@ -9,7 +9,7 @@
 # For example: 1.13.2-asm.5+config2:asmcli_1.13.2-asm.5-config2
 # The part before colon symbol should be used for ASM_PACKAGE_VERSION.
 # The part after colon symbol should be used for ASMCLI_SCRIPT_VERSION.
-
+SHELL := /bin/bash
 ASM_PACKAGE_VERSION=1.14.1-asm.3+config6
 ASMCLI_SCRIPT_VERSION=asmcli_1.14.1-asm.3-config6
 

--- a/kubeflow/asm/Makefile
+++ b/kubeflow/asm/Makefile
@@ -21,7 +21,7 @@ NAME=$(shell $(YQ) e '.data.name' kptconfig/kpt-setter-config.yaml)
 PROJECT=$(shell $(YQ) e '.data."gcloud.core.project"' kptconfig/kpt-setter-config.yaml)
 LOCATION=$(shell $(YQ) e '.data.location' kptconfig/kpt-setter-config.yaml)
 
-UPSTREAM=package
+UPSTREAM=./package
 
 .PHONY: download-asmcli
 download-asmcli: 

--- a/kubeflow/common/iap-ingress/Makefile
+++ b/kubeflow/common/iap-ingress/Makefile
@@ -24,9 +24,9 @@ check-iap:
 
 .PHONY: pod-reset
 pod-reset:
-	kubectl wait deployments/iap-enabler --for=condition=available --timeout=30s
-	kubectl wait deployments/cloud-endpoints-enabler --for=condition=available --timeout=30s
-	kubectl rollout status --watch --timeout=30s statefulset/backend-updater
+	kubectl wait deployments/iap-enabler -n istio-system --for=condition=available --timeout=30s
+	kubectl wait deployments/cloud-endpoints-enabler -n istio-system --for=condition=available --timeout=30s
+	kubectl rollout status --watch --timeout=30s -n istio-system statefulset/backend-updater
 	sleep 30
 	# Kick the IAP pod because we will reset the policy and need to patch it.
 	# TODO(https://github.com/kubeflow/gcp-blueprints/issues/14)

--- a/kubeflow/common/iap-ingress/Makefile
+++ b/kubeflow/common/iap-ingress/Makefile
@@ -27,7 +27,7 @@ pod-reset:
 	kubectl wait deployments/iap-enabler -n istio-system --for=condition=available --timeout=30s
 	kubectl wait deployments/cloud-endpoints-enabler -n istio-system --for=condition=available --timeout=30s
 	kubectl rollout status --watch --timeout=30s -n istio-system statefulset/backend-updater
-	sleep 30
+	sleep 90
 	# Kick the IAP pod because we will reset the policy and need to patch it.
 	# TODO(https://github.com/kubeflow/gcp-blueprints/issues/14)
 	kubectl --context=$(KFCTXT) -n istio-system delete deployment iap-enabler

--- a/kubeflow/common/managed-storage/cloudsql/sql-instance.yaml
+++ b/kubeflow/common/managed-storage/cloudsql/sql-instance.yaml
@@ -21,7 +21,7 @@ metadata:
 # Other examples to enable private cloudsql or high availability:
 # https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/tree/master/config-connector/solutions/sql/kpt
 spec:
-  databaseVersion: MYSQL_5_7
+  databaseVersion: MYSQL_8_0
   region: REGION # kpt-set: ${gcloud.compute.region}
   settings:
     # db-custom-1-3840 means a machine with 1 vCPU and 3840 MBs memory.

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -18,7 +18,7 @@ set -ex
 
 export KUBEFLOW_MANIFESTS_VERSION=v1.6.0
 export KUBEFLOW_MANIFESTS_REPO=https://github.com/kubeflow/manifests.git
-export KUBEFLOW_PIPELINES_VERSION=2.0.0-alpha.4
+export KUBEFLOW_PIPELINES_VERSION=2.0.0-alpha.5
 export KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git
 
 # Pull Kubeflow Pipelines upstream manifests.

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -16,7 +16,7 @@
 
 set -ex
 
-export KUBEFLOW_MANIFESTS_VERSION=v1.6.0
+export KUBEFLOW_MANIFESTS_VERSION=v1.6.1
 export KUBEFLOW_MANIFESTS_REPO=https://github.com/kubeflow/manifests.git
 export KUBEFLOW_PIPELINES_VERSION=2.0.0-alpha.5
 export KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -18,7 +18,7 @@ set -ex
 
 export KUBEFLOW_MANIFESTS_VERSION=v1.6.1
 export KUBEFLOW_MANIFESTS_REPO=https://github.com/kubeflow/manifests.git
-export KUBEFLOW_PIPELINES_VERSION=2.0.0-alpha.5
+export KUBEFLOW_PIPELINES_VERSION=2.0.0-alpha.6
 export KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git
 
 # Pull Kubeflow Pipelines upstream manifests.


### PR DESCRIPTION
Upgrading Kubeflow distribution for 1.6.1 release:
- [x] Upgrade upstream [manifests](https://github.com/kubeflow/manifests) to v 1.6.1
- [x] Upgrade upstream [KFP](https://github.com/kubeflow/pipelines) to v 2.0.0-alpha.6
- [x] Resolve #391 
- [x] Resolve #389 
- [x] Resolve #392
- [x] Updated CHANGELOG
- [x] Increased delay for IAP helper workloads to increase reliability of the deployment
- [x] Tested manually on GKE 1.22.