### PR TITLE
Set node image type to cos_containerd

### DIFF
--- a/management/manifests/cluster/nodepool.yaml
+++ b/management/manifests/cluster/nodepool.yaml
@@ -11,6 +11,7 @@ spec:
     diskSizeGb: 100
     diskType: pd-standard
     machineType: n1-standard-4
+    imageType: cos_containerd
     preemptible: false
     oauthScopes:
     - https://www.googleapis.com/auth/devstorage.read_only


### PR DESCRIPTION
Because docker based images are no longer supported in the regular channel we need to specify a containerd image for the node pool