### PR TITLE
Upgrade KNative to 1.8.5. Closes #404

### DIFF
--- a/kubeflow/common/knative/knative-1-8-5/net-istio.yaml
+++ b/kubeflow/common/knative/knative-1-8-5/net-istio.yaml
@@ -1,4 +1,4 @@
-# Generated when HEAD was dc8f82eb4cc1573fbaa6b7085b27dc77918d5233
+# Generated when HEAD was d4fce5da8b34ca56c7dd2724a389d85dba13ef69
 #
 # Copyright 2019 The Knative Authors
 #
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -21,14 +22,14 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.3"
     serving.knative.dev/controller: "true"
     networking.knative.dev/ingress-provider: istio
 rules:
   - apiGroups: ["networking.istio.io"]
     resources: ["virtualservices", "gateways", "destinationrules"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -43,6 +44,7 @@ rules:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 # This is the shared Gateway for all Knative routes to use.
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
@@ -52,8 +54,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.3"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -65,6 +66,7 @@ spec:
         protocol: HTTP
       hosts:
         - "*"
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -79,6 +81,7 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 # A cluster local gateway to allow pods outside of the mesh to access
 # Services and Routes not exposing through an ingress.  If the users
 # do have a service mesh setup, this isn't required.
@@ -90,8 +93,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.3"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -112,8 +114,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.3"
     networking.knative.dev/ingress-provider: istio
     experimental.istio.io/disable-gateway-port-translation: "true"
 spec:
@@ -124,6 +125,7 @@ spec:
     - name: http2
       port: 80
       targetPort: 8081
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -138,6 +140,7 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -146,10 +149,10 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.3"
     networking.knative.dev/ingress-provider: istio
 data:
+  # TODO(nghia): Extract the .svc.cluster.local suffix into its own config.
   _example: |
     ################################
     #                              #
@@ -189,18 +192,11 @@ data:
     # `knative-serving`
     local-gateway.knative-serving.knative-local-gateway: "knative-local-gateway.istio-system.svc.cluster.local"
 
-    # DEPRECATED: local-gateway.mesh is deprecated.
-    # See: https://github.com/knative/serving/issues/11523
-    #
-    # To use only Istio service mesh and no knative-local-gateway, replace
-    # all local-gateway.* entries by the following entry.
-    local-gateway.mesh: "mesh"
-
     # If true, knative will use the Istio VirtualService's status to determine
     # endpoint readiness. Otherwise, probe as usual.
     # NOTE: This feature is currently experimental and should not be used in production.
     enable-virtualservice-status: "false"
-  # TODO(nghia): Extract the .svc.cluster.local suffix into its own config.
+
 ---
 # Allows the Webhooks to be reached by kube-api with or without
 # sidecar injection and with mTLS PERMISSIVE and STRICT.
@@ -212,8 +208,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.3"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -231,8 +226,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.3"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -250,8 +244,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.3"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -260,6 +253,7 @@ spec:
   portLevelMtls:
     "8443":
       mode: PERMISSIVE
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -274,6 +268,7 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -282,8 +277,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.3"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -301,15 +295,14 @@ spec:
         app: net-istio-controller
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.2.0"
-        serving.knative.dev/release: "v1.2.0"
+        app.kubernetes.io/version: "1.8.3"
     spec:
       serviceAccountName: controller
       containers:
         - name: controller
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:f253b82941c2220181cee80d7488fe1cefce9d49ab30bdb54bcb8c76515f7a26
+          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:a76d0854c07c82266b59efd646d2df0e8dc6cd9671de780d892c9202641347ef
           resources:
             requests:
               cpu: 30m
@@ -326,6 +319,8 @@ spec:
               value: config-logging
             - name: CONFIG_OBSERVABILITY_NAME
               value: config-observability
+            - name: ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID
+              value: "false"
             # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
             - name: METRICS_DOMAIN
               value: knative.dev/net-istio
@@ -335,7 +330,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -344,6 +341,7 @@ spec:
 
 # Unlike other controllers, this doesn't need a Service defined for metrics and
 # profiling because it opts out of the mesh (see annotation above).
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -358,6 +356,7 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -366,8 +365,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.3"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -383,15 +381,14 @@ spec:
         role: net-istio-webhook
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.2.0"
-        serving.knative.dev/release: "v1.2.0"
+        app.kubernetes.io/version: "1.8.3"
     spec:
       serviceAccountName: controller
       containers:
         - name: webhook
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:a705c1ea8e9e556f860314fe055082fbe3cde6a924c29291955f98d979f8185e
+          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:e716c21c7aaa7ece064dae9690103c66598b5556bc1ce3f9ee4c4a71bc8630af
           resources:
             requests:
               cpu: 20m
@@ -414,7 +411,13 @@ spec:
             - name: WEBHOOK_NAME
               value: net-istio-webhook
           securityContext:
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -422,6 +425,7 @@ spec:
               containerPort: 8008
             - name: https-webhook
               containerPort: 8443
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -436,6 +440,7 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -444,9 +449,9 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.3"
     networking.knative.dev/ingress-provider: istio
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -461,6 +466,7 @@ metadata:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -470,8 +476,7 @@ metadata:
     role: net-istio-webhook
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.3"
     networking.knative.dev/ingress-provider: istio
 spec:
   ports:
@@ -487,6 +492,7 @@ spec:
       targetPort: 8443
   selector:
     app: net-istio-webhook
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -501,6 +507,7 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -508,8 +515,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.3"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:
@@ -525,6 +531,7 @@ webhooks:
       matchExpressions:
         - {key: "serving.knative.dev/configuration", operator: Exists}
     name: webhook.istio.networking.internal.knative.dev
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -539,6 +546,7 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -546,8 +554,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.3"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:
@@ -560,7 +567,9 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     name: config.webhook.istio.networking.internal.knative.dev
-    namespaceSelector:
-      matchExpressions:
-        - key: serving.knative.dev/release
-          operator: Exists
+    objectSelector:
+      matchLabels:
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/component: net-istio
+
+---

--- a/kubeflow/common/knative/knative-1-8-5/serving-core.yaml
+++ b/kubeflow/common/knative/knative-1-8-5/serving-core.yaml
@@ -11,14 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: Namespace
 metadata:
   name: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -33,6 +34,7 @@ metadata:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 # Use this aggregated ClusterRole when you need readonly access to "Addressables"
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -41,8 +43,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    serving.knative.dev/release: "v1.2.5"
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     app.kubernetes.io/name: knative-serving
 aggregationRule:
   clusterRoleSelectors:
@@ -54,8 +55,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    serving.knative.dev/release: "v1.2.5"
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     app.kubernetes.io/name: knative-serving
     # Labeled to facilitate aggregated cluster roles that act on Addressables.
     duck.knative.dev/addressable: "true"
@@ -72,6 +72,7 @@ rules:
       - get
       - list
       - watch
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -86,14 +87,14 @@ rules:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    serving.knative.dev/release: "v1.2.5"
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -109,8 +110,7 @@ metadata:
   name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    serving.knative.dev/release: "v1.2.5"
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -126,13 +126,13 @@ metadata:
   name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    serving.knative.dev/release: "v1.2.5"
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -147,14 +147,14 @@ rules:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
     serving.knative.dev/controller: "true"
-    serving.knative.dev/release: "v1.2.5"
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
@@ -187,6 +187,7 @@ rules:
   - apiGroups: ["caching.internal.knative.dev"]
     resources: ["images"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -201,13 +202,13 @@ rules:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    serving.knative.dev/release: "v1.2.5"
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     app.kubernetes.io/name: knative-serving
     # Labeled to facilitate aggregated cluster roles that act on PodSpecables.
     duck.knative.dev/podspecable: "true"
@@ -222,6 +223,7 @@ rules:
       - list
       - watch
       - patch
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -236,6 +238,7 @@ rules:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -244,8 +247,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -253,8 +255,7 @@ metadata:
   name: knative-serving-admin
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
@@ -267,8 +268,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -285,8 +285,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -295,6 +294,7 @@ roleRef:
   kind: ClusterRole
   name: knative-serving-aggregated-addressable-resolver
   apiGroup: rbac.authorization.k8s.io
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -309,13 +309,14 @@ roleRef:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: images.caching.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: caching.internal.knative.dev
@@ -326,8 +327,6 @@ spec:
     categories:
       - knative-internal
       - caching
-    shortNames:
-      - img
   scope: Namespaced
   versions:
     - name: v1alpha1
@@ -337,16 +336,86 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: Image is a Knative abstraction that encapsulates the interface by which Knative components express a desire to have a particular image cached.
           type: object
-          # this is a work around so we don't need to flush out the
-          # schema for each version at this time
-          #
-          # see issue: https://github.com/knative/serving/issues/912
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec holds the desired state of the Image (from the client).
+              type: object
+              required:
+                - image
+              properties:
+                image:
+                  description: Image is the name of the container image url to cache across the cluster.
+                  type: string
+                imagePullSecrets:
+                  description: ImagePullSecrets contains the names of the Kubernetes Secrets containing login information used by the Pods which will run this container.
+                  type: array
+                  items:
+                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                    type: object
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    x-kubernetes-map-type: atomic
+                serviceAccountName:
+                  description: 'ServiceAccountName is the name of the Kubernetes ServiceAccount as which the Pods will run this container.  This is potentially used to authenticate the image pull if the service account has attached pull secrets.  For more information: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account'
+                  type: string
+            status:
+              description: Status communicates the observed state of the Image (from the controller).
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
       additionalPrinterColumns:
         - name: Image
           type: string
           jsonPath: .spec.image
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -361,14 +430,15 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -380,12 +450,99 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: Certificate is responsible for provisioning a SSL certificate for the given hosts. It is a Knative abstraction for various SSL certificate provisioning solutions (such as cert-manager or self-signed SSL certificate).
           type: object
-          # this is a work around so we don't need to flush out the
-          # schema for each version at this time
-          #
-          # see issue: https://github.com/knative/serving/issues/912
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'Spec is the desired state of the Certificate. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              required:
+                - dnsNames
+                - secretName
+              properties:
+                dnsNames:
+                  description: DNSNames is a list of DNS names the Certificate could support. The wildcard format of DNSNames (e.g. *.default.example.com) is supported.
+                  type: array
+                  items:
+                    type: string
+                secretName:
+                  description: SecretName is the name of the secret resource to store the SSL certificate in.
+                  type: string
+            status:
+              description: 'Status is the current state of the Certificate. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                http01Challenges:
+                  description: HTTP01Challenges is a list of HTTP01 challenges that need to be fulfilled in order to get the TLS certificate..
+                  type: array
+                  items:
+                    description: HTTP01Challenge defines the status of a HTTP01 challenge that a certificate needs to fulfill.
+                    type: object
+                    properties:
+                      serviceName:
+                        description: ServiceName is the name of the service to serve HTTP01 challenge requests.
+                        type: string
+                      serviceNamespace:
+                        description: ServiceNamespace is the namespace of the service to serve HTTP01 challenge requests.
+                        type: string
+                      servicePort:
+                        description: ServicePort is the port of the service to serve HTTP01 challenge requests.
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
+                      url:
+                        description: URL is the URL that the HTTP01 challenge is expected to serve on.
+                        type: string
+                notAfter:
+                  description: The expiration time of the TLS certificate stored in the secret named by this resource in spec.secretName.
+                  type: string
+                  format: date-time
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
       additionalPrinterColumns:
         - name: Ready
           type: string
@@ -403,6 +560,7 @@ spec:
     shortNames:
       - kcert
   scope: Namespaced
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -419,14 +577,14 @@ spec:
 # limitations under the License.
 
 # Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: configurations.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -509,6 +667,10 @@ spec:
                       required:
                         - containers
                       properties:
+                        affinity:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         automountServiceAccountToken:
                           description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                           type: boolean
@@ -524,12 +686,12 @@ spec:
                             type: object
                             properties:
                               args:
-                                description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                 type: array
                                 items:
                                   type: string
                               command:
-                                description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                 type: array
                                 items:
                                   type: string
@@ -567,6 +729,17 @@ spec:
                                             optional:
                                               description: Specify whether the ConfigMap or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           description: Selects a key of a secret in the pod's namespace
                                           type: object
@@ -582,7 +755,7 @@ spec:
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
                                               type: boolean
-                                      x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                               envFrom:
                                 description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                 type: array
@@ -600,6 +773,7 @@ spec:
                                         optional:
                                           description: Specify whether the ConfigMap must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
@@ -613,8 +787,9 @@ spec:
                                         optional:
                                           description: Specify whether the Secret must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                               image:
-                                description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                                description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                 type: string
                               imagePullPolicy:
                                 description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -624,7 +799,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -662,10 +837,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -679,13 +859,18 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: TCPSocket specifies an action involving a TCP port.
                                     type: object
                                     properties:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -694,7 +879,7 @@ spec:
                                 description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                 type: string
                               ports:
-                                description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                                description: List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
                                 type: array
                                 items:
                                   description: ContainerPort represents a network port in a single container.
@@ -713,7 +898,6 @@ spec:
                                       description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                       type: string
                                       default: TCP
-                                  x-kubernetes-preserve-unknown-fields: true
                                 x-kubernetes-list-map-keys:
                                   - containerPort
                                   - protocol
@@ -723,7 +907,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -761,10 +945,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -778,13 +967,18 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: TCPSocket specifies an action involving a TCP port.
                                     type: object
                                     properties:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -815,25 +1009,39 @@ spec:
                                 description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                 type: object
                                 properties:
+                                  allowPrivilegeEscalation:
+                                    description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.'
+                                    type: boolean
                                   capabilities:
-                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                                     type: object
                                     properties:
+                                      add:
+                                        description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
                                       drop:
                                         description: Removed capabilities
                                         type: array
                                         items:
                                           description: Capability represent POSIX capabilities type
                                           type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   readOnlyRootFilesystem:
-                                    description: Whether this container has a read-only root filesystem. Default is false.
+                                    description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
-                                  runAsUser:
-                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
-                                x-kubernetes-preserve-unknown-fields: true
+                                  runAsNonRoot:
+                                    description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string
@@ -865,12 +1073,29 @@ spec:
                               workingDir:
                                 description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                        dnsConfig:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        dnsPolicy:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                          type: string
                         enableServiceLinks:
-                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
                           type: boolean
+                        hostAliases:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        idleTimeoutSeconds:
+                          description: IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed to stay open while not receiving any bytes from the user's application. If unspecified, a system default will be provided.
+                          type: integer
+                          format: int64
                         imagePullSecrets:
-                          description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                          description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                           type: array
                           items:
                             description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
@@ -879,13 +1104,60 @@ spec:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
+                            x-kubernetes-map-type: atomic
+                        initContainers:
+                          description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        nodeSelector:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          x-kubernetes-map-type: atomic
+                        priorityClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        responseStartTimeoutSeconds:
+                          description: ResponseStartTimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin sending any network traffic.
+                          type: integer
+                          format: int64
+                        runtimeClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        schedulerName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        securityContext:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         serviceAccountName:
                           description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                           type: string
                         timeoutSeconds:
-                          description: TimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (send network traffic). If unspecified, a system default will be provided.
+                          description: TimeoutSeconds is the maximum duration in seconds that the request instance is allowed to respond to a request. If unspecified, a system default will be provided.
                           type: integer
                           format: int64
+                        tolerations:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        topologySpreadConstraints:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         volumes:
                           description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                           type: array
@@ -896,15 +1168,15 @@ spec:
                               - name
                             properties:
                               configMap:
-                                description: ConfigMap represents a configMap that should populate this volume
+                                description: configMap represents a configMap that should populate this volume
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                     type: integer
                                     format: int32
                                   items:
-                                    description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                    description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                     type: array
                                     items:
                                       description: Maps a string key to a path within a volume.
@@ -914,45 +1186,54 @@ spec:
                                         - path
                                       properties:
                                         key:
-                                          description: The key to project.
+                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                           type: integer
                                           format: int32
                                         path:
-                                          description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                           type: string
                                   name:
                                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its keys must be defined
+                                    description: optional specify whether the ConfigMap or its keys must be defined
                                     type: boolean
+                                x-kubernetes-map-type: atomic
+                              emptyDir:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               name:
-                                description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
+                              persistentVolumeClaim:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               projected:
-                                description: Items for all in one resources secrets, configmaps, and downward API
+                                description: projected items for all in one resources secrets, configmaps, and downward API
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                    description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                     type: integer
                                     format: int32
                                   sources:
-                                    description: list of volume projections
+                                    description: sources is the list of volume projections
                                     type: array
                                     items:
                                       description: Projection that may be projected along with other supported volume types
                                       type: object
                                       properties:
                                         configMap:
-                                          description: information about the configMap data to project
+                                          description: configMap information about the configMap data to project
                                           type: object
                                           properties:
                                             items:
-                                              description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                              description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                               type: array
                                               items:
                                                 description: Maps a string key to a path within a volume.
@@ -962,27 +1243,28 @@ spec:
                                                   - path
                                                 properties:
                                                   key:
-                                                    description: The key to project.
+                                                    description: key is the key to project.
                                                     type: string
                                                   mode:
-                                                    description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                    description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                     type: integer
                                                     format: int32
                                                   path:
-                                                    description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                    description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                     type: string
                                             name:
                                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap or its keys must be defined
+                                              description: optional specify whether the ConfigMap or its keys must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         secret:
-                                          description: information about the secret data to project
+                                          description: secret information about the secret data to project
                                           type: object
                                           properties:
                                             items:
-                                              description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                              description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                               type: array
                                               items:
                                                 description: Maps a string key to a path within a volume.
@@ -992,47 +1274,48 @@ spec:
                                                   - path
                                                 properties:
                                                   key:
-                                                    description: The key to project.
+                                                    description: key is the key to project.
                                                     type: string
                                                   mode:
-                                                    description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                    description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                     type: integer
                                                     format: int32
                                                   path:
-                                                    description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                    description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                     type: string
                                             name:
                                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret or its key must be defined
+                                              description: optional field specify whether the Secret or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         serviceAccountToken:
-                                          description: information about the serviceAccountToken data to project
+                                          description: serviceAccountToken is information about the serviceAccountToken data to project
                                           type: object
                                           required:
                                             - path
                                           properties:
                                             audience:
-                                              description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                              description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                               type: string
                                             expirationSeconds:
-                                              description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                              description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                               type: integer
                                               format: int64
                                             path:
-                                              description: Path is the path relative to the mount point of the file to project the token into.
+                                              description: path is the path relative to the mount point of the file to project the token into.
                                               type: string
                               secret:
-                                description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                     type: integer
                                     format: int32
                                   items:
-                                    description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                    description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                     type: array
                                     items:
                                       description: Maps a string key to a path within a volume.
@@ -1042,23 +1325,21 @@ spec:
                                         - path
                                       properties:
                                         key:
-                                          description: The key to project.
+                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                           type: integer
                                           format: int32
                                         path:
-                                          description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                           type: string
                                   optional:
-                                    description: Specify whether the Secret or its keys must be defined
+                                    description: optional field specify whether the Secret or its keys must be defined
                                     type: boolean
                                   secretName:
-                                    description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
-                            x-kubernetes-preserve-unknown-fields: true
-                      x-kubernetes-preserve-unknown-fields: true
             status:
               description: ConfigurationStatus communicates the observed state of the Configuration (from the controller).
               type: object
@@ -1081,7 +1362,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -1107,6 +1387,7 @@ spec:
                   description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                   type: integer
                   format: int64
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -1121,14 +1402,15 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterdomainclaims.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1140,12 +1422,26 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: ClusterDomainClaim is a cluster-wide reservation for a particular domain name.
           type: object
-          # this is a work around so we don't need to flush out the
-          # schema for each version at this time
-          #
-          # see issue: https://github.com/knative/serving/issues/912
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'Spec is the desired state of the ClusterDomainClaim. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              required:
+                - namespace
+              properties:
+                namespace:
+                  description: Namespace is the namespace which is allowed to create a DomainMapping using this ClusterDomainClaim's name.
+                  type: string
   names:
     kind: ClusterDomainClaim
     plural: clusterdomainclaims
@@ -1156,6 +1452,7 @@ spec:
     shortNames:
       - cdc
   scope: Cluster
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -1170,14 +1467,14 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: domainmappings.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -1275,7 +1572,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -1381,7 +1677,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -1425,6 +1720,7 @@ spec:
     shortNames:
       - dm
   scope: Namespaced
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -1439,14 +1735,15 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ingresses.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1458,12 +1755,212 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable URLs, load balance traffic, offer name based virtual hosting, etc. \n This is heavily based on K8s Ingress https://godoc.org/k8s.io/api/networking/v1beta1#Ingress which some highlighted modifications."
           type: object
-          # this is a work around so we don't need to flush out the
-          # schema for each version at this time
-          #
-          # see issue: https://github.com/knative/serving/issues/912
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'Spec is the desired state of the Ingress. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              properties:
+                httpOption:
+                  description: 'HTTPOption is the option of HTTP. It has the following two values: `HTTPOptionEnabled`, `HTTPOptionRedirected`'
+                  type: string
+                rules:
+                  description: A list of host rules used to configure the Ingress.
+                  type: array
+                  items:
+                    description: IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.
+                    type: object
+                    properties:
+                      hosts:
+                        description: 'Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently a rule value can only apply to the IP in the Spec of the parent . 2. The `:` delimiter is not respected because ports are not allowed. Currently the port of an Ingress is implicitly :80 for http and :443 for https. Both these may change in the future. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue. If multiple matching Hosts were provided, the first rule will take precedent.'
+                        type: array
+                        items:
+                          type: string
+                      http:
+                        description: HTTP represents a rule to apply against incoming requests. If the rule is satisfied, the request is routed to the specified backend.
+                        type: object
+                        required:
+                          - paths
+                        properties:
+                          paths:
+                            description: "A collection of paths that map requests to backends. \n If they are multiple matching paths, the first match takes precedence."
+                            type: array
+                            items:
+                              description: HTTPIngressPath associates a path regex with a backend. Incoming URLs matching the path are forwarded to the backend.
+                              type: object
+                              required:
+                                - splits
+                              properties:
+                                appendHeaders:
+                                  description: "AppendHeaders allow specifying additional HTTP headers to add before forwarding a request to the destination service. \n NOTE: This differs from K8s Ingress which doesn't allow header appending."
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                headers:
+                                  description: Headers defines header matching rules which is a map from a header name to HeaderMatch which specify a matching condition. When a request matched with all the header matching rules, the request is routed by the corresponding ingress rule. If it is empty, the headers are not used for matching
+                                  type: object
+                                  additionalProperties:
+                                    description: HeaderMatch represents a matching value of Headers in HTTPIngressPath. Currently, only the exact matching is supported.
+                                    type: object
+                                    required:
+                                      - exact
+                                    properties:
+                                      exact:
+                                        type: string
+                                path:
+                                  description: Path represents a literal prefix to which this rule should apply. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.
+                                  type: string
+                                rewriteHost:
+                                  description: "RewriteHost rewrites the incoming request's host header. \n This field is currently experimental and not supported by all Ingress implementations."
+                                  type: string
+                                splits:
+                                  description: Splits defines the referenced service endpoints to which the traffic will be forwarded to.
+                                  type: array
+                                  items:
+                                    description: IngressBackendSplit describes all endpoints for a given service and port.
+                                    type: object
+                                    required:
+                                      - serviceName
+                                      - serviceNamespace
+                                      - servicePort
+                                    properties:
+                                      appendHeaders:
+                                        description: "AppendHeaders allow specifying additional HTTP headers to add before forwarding a request to the destination service. \n NOTE: This differs from K8s Ingress which doesn't allow header appending."
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      percent:
+                                        description: "Specifies the split percentage, a number between 0 and 100.  If only one split is specified, we default to 100. \n NOTE: This differs from K8s Ingress to allow percentage split."
+                                        type: integer
+                                      serviceName:
+                                        description: Specifies the name of the referenced service.
+                                        type: string
+                                      serviceNamespace:
+                                        description: "Specifies the namespace of the referenced service. \n NOTE: This differs from K8s Ingress to allow routing to different namespaces."
+                                        type: string
+                                      servicePort:
+                                        description: Specifies the port of the referenced service.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                      visibility:
+                        description: Visibility signifies whether this rule should `ClusterLocal`. If it's not specified then it defaults to `ExternalIP`.
+                        type: string
+                tls:
+                  description: 'TLS configuration. Currently Ingress only supports a single TLS port: 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.'
+                  type: array
+                  items:
+                    description: IngressTLS describes the transport layer security associated with an Ingress.
+                    type: object
+                    properties:
+                      hosts:
+                        description: Hosts is a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.
+                        type: array
+                        items:
+                          type: string
+                      secretName:
+                        description: SecretName is the name of the secret used to terminate SSL traffic.
+                        type: string
+                      secretNamespace:
+                        description: SecretNamespace is the namespace of the secret used to terminate SSL traffic. If not set the namespace should be assumed to be the same as the Ingress. If set the secret should have the same namespace as the Ingress otherwise the behaviour is undefined and not supported.
+                        type: string
+            status:
+              description: 'Status is the current state of the Ingress. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
+                privateLoadBalancer:
+                  description: PrivateLoadBalancer contains the current status of the load-balancer.
+                  type: object
+                  properties:
+                    ingress:
+                      description: Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
+                      type: array
+                      items:
+                        description: 'LoadBalancerIngressStatus represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.'
+                        type: object
+                        properties:
+                          domain:
+                            description: Domain is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)
+                            type: string
+                          domainInternal:
+                            description: "DomainInternal is set if there is a cluster-local DNS name to access the Ingress. \n NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local DNS name to allow routing in case of not having a mesh."
+                            type: string
+                          ip:
+                            description: IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)
+                            type: string
+                          meshOnly:
+                            description: MeshOnly is set if the Ingress is only load-balanced through a Service mesh.
+                            type: boolean
+                publicLoadBalancer:
+                  description: PublicLoadBalancer contains the current status of the load-balancer.
+                  type: object
+                  properties:
+                    ingress:
+                      description: Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
+                      type: array
+                      items:
+                        description: 'LoadBalancerIngressStatus represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.'
+                        type: object
+                        properties:
+                          domain:
+                            description: Domain is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)
+                            type: string
+                          domainInternal:
+                            description: "DomainInternal is set if there is a cluster-local DNS name to access the Ingress. \n NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local DNS name to allow routing in case of not having a mesh."
+                            type: string
+                          ip:
+                            description: IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)
+                            type: string
+                          meshOnly:
+                            description: MeshOnly is set if the Ingress is only load-balanced through a Service mesh.
+                            type: boolean
       additionalPrinterColumns:
         - name: Ready
           type: string
@@ -1482,6 +1979,7 @@ spec:
       - kingress
       - king
   scope: Namespaced
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -1498,14 +1996,14 @@ spec:
 # limitations under the License.
 
 # Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1584,7 +2082,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -1604,6 +2101,7 @@ spec:
                   description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                   type: integer
                   format: int64
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -1620,14 +2118,14 @@ spec:
 # limitations under the License.
 
 # Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1663,7 +2161,7 @@ spec:
           jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
       schema:
         openAPIV3Schema:
-          description: 'PodAutoscaler is a Knative abstraction that encapsulates the interface by which Knative components instantiate autoscalers.  This definition is an abstraction that may be backed by multiple definitions.  For more information, see the Knative Pluggability presentation: https://docs.google.com/presentation/d/10KWynvAJYuOEWy69VBa6bHJVCqIsz1TNdEKosNvcpPY/edit'
+          description: 'PodAutoscaler is a Knative abstraction that encapsulates the interface by which Knative components instantiate autoscalers.  This definition is an abstraction that may be backed by multiple definitions.  For more information, see the Knative Pluggability presentation: https://docs.google.com/presentation/d/19vW9HFZ6Puxt31biNZF3uLRejDmu82rxJIk1cWmxF7w/edit'
           type: object
           properties:
             apiVersion:
@@ -1704,6 +2202,7 @@ spec:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
+                  x-kubernetes-map-type: atomic
             status:
               description: Status communicates the observed state of the PodAutoscaler (from the controller).
               type: object
@@ -1733,7 +2232,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -1763,6 +2261,7 @@ spec:
                 serviceName:
                   description: ServiceName is the K8s Service name that serves the revision, scaled by this PA. The service is created and owned by the ServerlessService object owned by this PA.
                   type: string
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -1779,14 +2278,14 @@ spec:
 # limitations under the License.
 
 # Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: revisions.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -1848,6 +2347,10 @@ spec:
               required:
                 - containers
               properties:
+                affinity:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 automountServiceAccountToken:
                   description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                   type: boolean
@@ -1863,12 +2366,12 @@ spec:
                     type: object
                     properties:
                       args:
-                        description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                         type: array
                         items:
                           type: string
                       command:
-                        description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                         type: array
                         items:
                           type: string
@@ -1906,6 +2409,17 @@ spec:
                                     optional:
                                       description: Specify whether the ConfigMap or its key must be defined
                                       type: boolean
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's namespace
                                   type: object
@@ -1921,7 +2435,7 @@ spec:
                                     optional:
                                       description: Specify whether the Secret or its key must be defined
                                       type: boolean
-                              x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
                       envFrom:
                         description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                         type: array
@@ -1939,6 +2453,7 @@ spec:
                                 optional:
                                   description: Specify whether the ConfigMap must be defined
                                   type: boolean
+                              x-kubernetes-map-type: atomic
                             prefix:
                               description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                               type: string
@@ -1952,8 +2467,9 @@ spec:
                                 optional:
                                   description: Specify whether the Secret must be defined
                                   type: boolean
+                              x-kubernetes-map-type: atomic
                       image:
-                        description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                        description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                         type: string
                       imagePullPolicy:
                         description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -1963,7 +2479,7 @@ spec:
                         type: object
                         properties:
                           exec:
-                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                            description: Exec specifies the action to take.
                             type: object
                             properties:
                               command:
@@ -2001,10 +2517,15 @@ spec:
                               path:
                                 description: Path to access on the HTTP server.
                                 type: string
+                              port:
+                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host. Defaults to HTTP.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
                           initialDelaySeconds:
                             description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -2018,13 +2539,18 @@ spec:
                             type: integer
                             format: int32
                           tcpSocket:
-                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                            description: TCPSocket specifies an action involving a TCP port.
                             type: object
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                              port:
+                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                           timeoutSeconds:
                             description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -2033,7 +2559,7 @@ spec:
                         description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                         type: string
                       ports:
-                        description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                        description: List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
                         type: array
                         items:
                           description: ContainerPort represents a network port in a single container.
@@ -2052,7 +2578,6 @@ spec:
                               description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                               type: string
                               default: TCP
-                          x-kubernetes-preserve-unknown-fields: true
                         x-kubernetes-list-map-keys:
                           - containerPort
                           - protocol
@@ -2062,7 +2587,7 @@ spec:
                         type: object
                         properties:
                           exec:
-                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                            description: Exec specifies the action to take.
                             type: object
                             properties:
                               command:
@@ -2100,10 +2625,15 @@ spec:
                               path:
                                 description: Path to access on the HTTP server.
                                 type: string
+                              port:
+                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host. Defaults to HTTP.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
                           initialDelaySeconds:
                             description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -2117,13 +2647,18 @@ spec:
                             type: integer
                             format: int32
                           tcpSocket:
-                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                            description: TCPSocket specifies an action involving a TCP port.
                             type: object
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                              port:
+                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                           timeoutSeconds:
                             description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -2154,25 +2689,39 @@ spec:
                         description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                         type: object
                         properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.'
+                            type: boolean
                           capabilities:
-                            description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                            description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                             type: object
                             properties:
+                              add:
+                                description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                type: array
+                                items:
+                                  description: Capability represent POSIX capabilities type
+                                  type: string
                               drop:
                                 description: Removed capabilities
                                 type: array
                                 items:
                                   description: Capability represent POSIX capabilities type
                                   type: string
-                            x-kubernetes-preserve-unknown-fields: true
                           readOnlyRootFilesystem:
-                            description: Whether this container has a read-only root filesystem. Default is false.
+                            description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
-                          runAsUser:
-                            description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             type: integer
                             format: int64
-                        x-kubernetes-preserve-unknown-fields: true
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                            type: integer
+                            format: int64
                       terminationMessagePath:
                         description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                         type: string
@@ -2204,12 +2753,29 @@ spec:
                       workingDir:
                         description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                         type: string
-                    x-kubernetes-preserve-unknown-fields: true
+                dnsConfig:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                dnsPolicy:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                  type: string
                 enableServiceLinks:
-                  description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                  description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
                   type: boolean
+                hostAliases:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                idleTimeoutSeconds:
+                  description: IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed to stay open while not receiving any bytes from the user's application. If unspecified, a system default will be provided.
+                  type: integer
+                  format: int64
                 imagePullSecrets:
-                  description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                  description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                   type: array
                   items:
                     description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
@@ -2218,13 +2784,60 @@ spec:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
+                    x-kubernetes-map-type: atomic
+                initContainers:
+                  description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                nodeSelector:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-map-type: atomic
+                priorityClassName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                responseStartTimeoutSeconds:
+                  description: ResponseStartTimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin sending any network traffic.
+                  type: integer
+                  format: int64
+                runtimeClassName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                schedulerName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                securityContext:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 serviceAccountName:
                   description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                   type: string
                 timeoutSeconds:
-                  description: TimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (send network traffic). If unspecified, a system default will be provided.
+                  description: TimeoutSeconds is the maximum duration in seconds that the request instance is allowed to respond to a request. If unspecified, a system default will be provided.
                   type: integer
                   format: int64
+                tolerations:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                topologySpreadConstraints:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 volumes:
                   description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                   type: array
@@ -2235,15 +2848,15 @@ spec:
                       - name
                     properties:
                       configMap:
-                        description: ConfigMap represents a configMap that should populate this volume
+                        description: configMap represents a configMap that should populate this volume
                         type: object
                         properties:
                           defaultMode:
-                            description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                            description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                             type: integer
                             format: int32
                           items:
-                            description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                             type: array
                             items:
                               description: Maps a string key to a path within a volume.
@@ -2253,45 +2866,54 @@ spec:
                                 - path
                               properties:
                                 key:
-                                  description: The key to project.
+                                  description: key is the key to project.
                                   type: string
                                 mode:
-                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   type: integer
                                   format: int32
                                 path:
-                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                   type: string
                           name:
                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the ConfigMap or its keys must be defined
+                            description: optional specify whether the ConfigMap or its keys must be defined
                             type: boolean
+                        x-kubernetes-map-type: atomic
+                      emptyDir:
+                        description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       name:
-                        description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
+                      persistentVolumeClaim:
+                        description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       projected:
-                        description: Items for all in one resources secrets, configmaps, and downward API
+                        description: projected items for all in one resources secrets, configmaps, and downward API
                         type: object
                         properties:
                           defaultMode:
-                            description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                            description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                             type: integer
                             format: int32
                           sources:
-                            description: list of volume projections
+                            description: sources is the list of volume projections
                             type: array
                             items:
                               description: Projection that may be projected along with other supported volume types
                               type: object
                               properties:
                                 configMap:
-                                  description: information about the configMap data to project
+                                  description: configMap information about the configMap data to project
                                   type: object
                                   properties:
                                     items:
-                                      description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                       type: array
                                       items:
                                         description: Maps a string key to a path within a volume.
@@ -2301,27 +2923,28 @@ spec:
                                           - path
                                         properties:
                                           key:
-                                            description: The key to project.
+                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                             type: integer
                                             format: int32
                                           path:
-                                            description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                             type: string
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or its keys must be defined
+                                      description: optional specify whether the ConfigMap or its keys must be defined
                                       type: boolean
+                                  x-kubernetes-map-type: atomic
                                 secret:
-                                  description: information about the secret data to project
+                                  description: secret information about the secret data to project
                                   type: object
                                   properties:
                                     items:
-                                      description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                       type: array
                                       items:
                                         description: Maps a string key to a path within a volume.
@@ -2331,47 +2954,48 @@ spec:
                                           - path
                                         properties:
                                           key:
-                                            description: The key to project.
+                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                             type: integer
                                             format: int32
                                           path:
-                                            description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                             type: string
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its key must be defined
+                                      description: optional field specify whether the Secret or its key must be defined
                                       type: boolean
+                                  x-kubernetes-map-type: atomic
                                 serviceAccountToken:
-                                  description: information about the serviceAccountToken data to project
+                                  description: serviceAccountToken is information about the serviceAccountToken data to project
                                   type: object
                                   required:
                                     - path
                                   properties:
                                     audience:
-                                      description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                      description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                       type: string
                                     expirationSeconds:
-                                      description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                      description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                       type: integer
                                       format: int64
                                     path:
-                                      description: Path is the path relative to the mount point of the file to project the token into.
+                                      description: path is the path relative to the mount point of the file to project the token into.
                                       type: string
                       secret:
-                        description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                         type: object
                         properties:
                           defaultMode:
-                            description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                            description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                             type: integer
                             format: int32
                           items:
-                            description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                            description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                             type: array
                             items:
                               description: Maps a string key to a path within a volume.
@@ -2381,23 +3005,21 @@ spec:
                                 - path
                               properties:
                                 key:
-                                  description: The key to project.
+                                  description: key is the key to project.
                                   type: string
                                 mode:
-                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   type: integer
                                   format: int32
                                 path:
-                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                   type: string
                           optional:
-                            description: Specify whether the Secret or its keys must be defined
+                            description: optional field specify whether the Secret or its keys must be defined
                             type: boolean
                           secretName:
-                            description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                             type: string
-                    x-kubernetes-preserve-unknown-fields: true
-              x-kubernetes-preserve-unknown-fields: true
             status:
               description: RevisionStatus communicates the observed state of the Revision (from the controller).
               type: object
@@ -2424,7 +3046,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -2473,6 +3094,7 @@ spec:
                   description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                   type: integer
                   format: int64
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -2489,14 +3111,14 @@ spec:
 # limitations under the License.
 
 # Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: routes.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -2559,7 +3181,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:
@@ -2599,7 +3221,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -2633,7 +3254,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:
@@ -2648,6 +3269,7 @@ spec:
                 url:
                   description: URL holds the url that will distribute traffic over the provided traffic targets. It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}
                   type: string
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -2662,14 +3284,15 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: serverlessservices.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2681,12 +3304,107 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: 'ServerlessService is a proxy for the K8s service objects containing the endpoints for the revision, whether those are endpoints of the activator or revision pods. See: https://knative.page.link/naxz for details.'
           type: object
-          # this is a work around so we don't need to flush out the
-          # schema for each version at this time
-          #
-          # see issue: https://github.com/knative/serving/issues/912
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'Spec is the desired state of the ServerlessService. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              required:
+                - objectRef
+                - protocolType
+              properties:
+                mode:
+                  description: Mode describes the mode of operation of the ServerlessService.
+                  type: string
+                numActivators:
+                  description: NumActivators contains number of Activators that this revision should be assigned. O means — assign all.
+                  type: integer
+                  format: int32
+                objectRef:
+                  description: ObjectRef defines the resource that this ServerlessService is responsible for making "serverless".
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  x-kubernetes-map-type: atomic
+                protocolType:
+                  description: The application-layer protocol. Matches `RevisionProtocolType` set on the owning pa/revision. serving imports networking, so just use string.
+                  type: string
+            status:
+              description: 'Status is the current state of the ServerlessService. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
+                privateServiceName:
+                  description: PrivateServiceName holds the name of a core K8s Service resource that load balances over the user service pods backing this Revision.
+                  type: string
+                serviceName:
+                  description: ServiceName holds the name of a core K8s Service resource that load balances over the pods backing this Revision (activator or revision).
+                  type: string
       additionalPrinterColumns:
         - name: Mode
           type: string
@@ -2716,6 +3434,7 @@ spec:
     shortNames:
       - sks
   scope: Namespaced
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -2732,14 +3451,14 @@ spec:
 # limitations under the License.
 
 # Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: services.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -2826,6 +3545,10 @@ spec:
                       required:
                         - containers
                       properties:
+                        affinity:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         automountServiceAccountToken:
                           description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                           type: boolean
@@ -2841,12 +3564,12 @@ spec:
                             type: object
                             properties:
                               args:
-                                description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                 type: array
                                 items:
                                   type: string
                               command:
-                                description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                 type: array
                                 items:
                                   type: string
@@ -2884,6 +3607,17 @@ spec:
                                             optional:
                                               description: Specify whether the ConfigMap or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           description: Selects a key of a secret in the pod's namespace
                                           type: object
@@ -2899,7 +3633,7 @@ spec:
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
                                               type: boolean
-                                      x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                               envFrom:
                                 description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                 type: array
@@ -2917,6 +3651,7 @@ spec:
                                         optional:
                                           description: Specify whether the ConfigMap must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
@@ -2930,8 +3665,9 @@ spec:
                                         optional:
                                           description: Specify whether the Secret must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                               image:
-                                description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                                description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                 type: string
                               imagePullPolicy:
                                 description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -2941,7 +3677,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -2979,10 +3715,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -2996,13 +3737,18 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: TCPSocket specifies an action involving a TCP port.
                                     type: object
                                     properties:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -3011,7 +3757,7 @@ spec:
                                 description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                 type: string
                               ports:
-                                description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                                description: List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
                                 type: array
                                 items:
                                   description: ContainerPort represents a network port in a single container.
@@ -3030,7 +3776,6 @@ spec:
                                       description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                       type: string
                                       default: TCP
-                                  x-kubernetes-preserve-unknown-fields: true
                                 x-kubernetes-list-map-keys:
                                   - containerPort
                                   - protocol
@@ -3040,7 +3785,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -3078,10 +3823,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -3095,13 +3845,18 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: TCPSocket specifies an action involving a TCP port.
                                     type: object
                                     properties:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -3132,25 +3887,39 @@ spec:
                                 description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                 type: object
                                 properties:
+                                  allowPrivilegeEscalation:
+                                    description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.'
+                                    type: boolean
                                   capabilities:
-                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                                     type: object
                                     properties:
+                                      add:
+                                        description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
                                       drop:
                                         description: Removed capabilities
                                         type: array
                                         items:
                                           description: Capability represent POSIX capabilities type
                                           type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   readOnlyRootFilesystem:
-                                    description: Whether this container has a read-only root filesystem. Default is false.
+                                    description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
-                                  runAsUser:
-                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
-                                x-kubernetes-preserve-unknown-fields: true
+                                  runAsNonRoot:
+                                    description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string
@@ -3182,12 +3951,29 @@ spec:
                               workingDir:
                                 description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                        dnsConfig:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        dnsPolicy:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                          type: string
                         enableServiceLinks:
-                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
                           type: boolean
+                        hostAliases:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        idleTimeoutSeconds:
+                          description: IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed to stay open while not receiving any bytes from the user's application. If unspecified, a system default will be provided.
+                          type: integer
+                          format: int64
                         imagePullSecrets:
-                          description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                          description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                           type: array
                           items:
                             description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
@@ -3196,13 +3982,60 @@ spec:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
+                            x-kubernetes-map-type: atomic
+                        initContainers:
+                          description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        nodeSelector:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          x-kubernetes-map-type: atomic
+                        priorityClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        responseStartTimeoutSeconds:
+                          description: ResponseStartTimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin sending any network traffic.
+                          type: integer
+                          format: int64
+                        runtimeClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        schedulerName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        securityContext:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         serviceAccountName:
                           description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                           type: string
                         timeoutSeconds:
-                          description: TimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (send network traffic). If unspecified, a system default will be provided.
+                          description: TimeoutSeconds is the maximum duration in seconds that the request instance is allowed to respond to a request. If unspecified, a system default will be provided.
                           type: integer
                           format: int64
+                        tolerations:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        topologySpreadConstraints:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         volumes:
                           description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                           type: array
@@ -3213,15 +4046,15 @@ spec:
                               - name
                             properties:
                               configMap:
-                                description: ConfigMap represents a configMap that should populate this volume
+                                description: configMap represents a configMap that should populate this volume
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                     type: integer
                                     format: int32
                                   items:
-                                    description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                    description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                     type: array
                                     items:
                                       description: Maps a string key to a path within a volume.
@@ -3231,45 +4064,54 @@ spec:
                                         - path
                                       properties:
                                         key:
-                                          description: The key to project.
+                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                           type: integer
                                           format: int32
                                         path:
-                                          description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                           type: string
                                   name:
                                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its keys must be defined
+                                    description: optional specify whether the ConfigMap or its keys must be defined
                                     type: boolean
+                                x-kubernetes-map-type: atomic
+                              emptyDir:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               name:
-                                description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
+                              persistentVolumeClaim:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               projected:
-                                description: Items for all in one resources secrets, configmaps, and downward API
+                                description: projected items for all in one resources secrets, configmaps, and downward API
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                    description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                     type: integer
                                     format: int32
                                   sources:
-                                    description: list of volume projections
+                                    description: sources is the list of volume projections
                                     type: array
                                     items:
                                       description: Projection that may be projected along with other supported volume types
                                       type: object
                                       properties:
                                         configMap:
-                                          description: information about the configMap data to project
+                                          description: configMap information about the configMap data to project
                                           type: object
                                           properties:
                                             items:
-                                              description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                              description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                               type: array
                                               items:
                                                 description: Maps a string key to a path within a volume.
@@ -3279,27 +4121,28 @@ spec:
                                                   - path
                                                 properties:
                                                   key:
-                                                    description: The key to project.
+                                                    description: key is the key to project.
                                                     type: string
                                                   mode:
-                                                    description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                    description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                     type: integer
                                                     format: int32
                                                   path:
-                                                    description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                    description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                     type: string
                                             name:
                                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap or its keys must be defined
+                                              description: optional specify whether the ConfigMap or its keys must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         secret:
-                                          description: information about the secret data to project
+                                          description: secret information about the secret data to project
                                           type: object
                                           properties:
                                             items:
-                                              description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                              description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                               type: array
                                               items:
                                                 description: Maps a string key to a path within a volume.
@@ -3309,47 +4152,48 @@ spec:
                                                   - path
                                                 properties:
                                                   key:
-                                                    description: The key to project.
+                                                    description: key is the key to project.
                                                     type: string
                                                   mode:
-                                                    description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                    description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                     type: integer
                                                     format: int32
                                                   path:
-                                                    description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                    description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                     type: string
                                             name:
                                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret or its key must be defined
+                                              description: optional field specify whether the Secret or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         serviceAccountToken:
-                                          description: information about the serviceAccountToken data to project
+                                          description: serviceAccountToken is information about the serviceAccountToken data to project
                                           type: object
                                           required:
                                             - path
                                           properties:
                                             audience:
-                                              description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                              description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                               type: string
                                             expirationSeconds:
-                                              description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                              description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                               type: integer
                                               format: int64
                                             path:
-                                              description: Path is the path relative to the mount point of the file to project the token into.
+                                              description: path is the path relative to the mount point of the file to project the token into.
                                               type: string
                               secret:
-                                description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                     type: integer
                                     format: int32
                                   items:
-                                    description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                    description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                     type: array
                                     items:
                                       description: Maps a string key to a path within a volume.
@@ -3359,23 +4203,21 @@ spec:
                                         - path
                                       properties:
                                         key:
-                                          description: The key to project.
+                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                           type: integer
                                           format: int32
                                         path:
-                                          description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                           type: string
                                   optional:
-                                    description: Specify whether the Secret or its keys must be defined
+                                    description: optional field specify whether the Secret or its keys must be defined
                                     type: boolean
                                   secretName:
-                                    description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
-                            x-kubernetes-preserve-unknown-fields: true
-                      x-kubernetes-preserve-unknown-fields: true
                 traffic:
                   description: Traffic specifies how to distribute traffic over a collection of revisions and configurations.
                   type: array
@@ -3390,7 +4232,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:
@@ -3430,7 +4272,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -3470,7 +4311,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:
@@ -3485,6 +4326,45 @@ spec:
                 url:
                   description: URL holds the url that will distribute traffic over the provided traffic targets. It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}
                   type: string
+
+---
+# Copyright 2022 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  # Do not drop -ctrl-ca suffix as control-protocol requires it.
+  # https://github.com/knative-sandbox/control-protocol/blob/main/pkg/certificates/reconciler/controller.go
+  name: serving-certs-ctrl-ca
+  namespace: knative-serving
+  labels:
+    serving-certs-ctrl: "data-plane"
+    networking.internal.knative.dev/certificate-uid: "serving-certs"
+
+# The data is populated when internal-encryption is enabled.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: knative-serving-certs
+  namespace: knative-serving
+  labels:
+    serving-certs-ctrl: "data-plane"
+    networking.internal.knative.dev/certificate-uid: "serving-certs"
+# The data is populated when internal-encryption is enabled.
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -3499,6 +4379,7 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: caching.internal.knative.dev/v1alpha1
 kind: Image
 metadata:
@@ -3507,12 +4388,12 @@ metadata:
   labels:
     app.kubernetes.io/component: queue-proxy
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
-  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:14415b204ea8d0567235143a6c3377f49cbd35f18dc84dfa4baa7695c2a9b53d
+  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:545c7414f9bc93763c5e41567a5fd6f3359d4d186700b8b28b1411e1c899a2c2
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -3527,6 +4408,7 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -3535,10 +4417,9 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
   annotations:
-    knative.dev/example-checksum: "16af78ce"
+    knative.dev/example-checksum: "47c2487f"
 data:
   _example: |
     ################################
@@ -3613,7 +4494,7 @@ data:
     # -1 denotes unlimited target-burst-capacity and activator will always
     # be in the request path.
     # Other negative values are invalid.
-    target-burst-capacity: "200"
+    target-burst-capacity: "211"
 
     # When operating in a stable mode, the autoscaler operates on the
     # average concurrency over the stable window.
@@ -3723,6 +4604,7 @@ data:
     # (including a maxScale of "0" = unlimited) is disallowed.
     # A value of zero (the default) allows any limit, including unlimited.
     max-scale-limit: "0"
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -3737,6 +4619,7 @@ data:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -3745,10 +4628,9 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
   annotations:
-    knative.dev/example-checksum: "a0feb4c6"
+    knative.dev/example-checksum: "e7973912"
 data:
   _example: |
     ################################
@@ -3779,6 +4661,18 @@ data:
     # If this value is increased, the activator's terminationGraceTimeSeconds
     # should also be increased to prevent in-flight requests being disrupted.
     max-revision-timeout-seconds: "600"  # 10 minutes
+
+    # revision-response-start-timeout-seconds contains the default number of
+    # seconds a request will be allowed to stay open while waiting to
+    # receive any bytes from the user's application, if none is specified.
+    #
+    # This defaults to 'revision-timeout-seconds'
+    revision-response-start-timeout-seconds: "300"
+
+    # revision-idle-timeout-seconds contains the default number of
+    # seconds a request will be allowed to stay open while not receiving any
+    # bytes from the user's application, if none is specified.
+    revision-idle-timeout-seconds: "0"  # infinite
 
     # revision-cpu-request contains the cpu allocation to assign
     # to revisions by default.  If omitted, no value is specified
@@ -3865,6 +4759,7 @@ data:
     # to set this value to `false`.
     # See https://github.com/knative/serving/issues/8498.
     enable-service-links: "false"
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -3879,6 +4774,7 @@ data:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -3887,15 +4783,13 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
   annotations:
     knative.dev/example-checksum: "dd7ee769"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
-  # TODO: switch to 'queue-sidecar-image' after 0.27
-  queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:14415b204ea8d0567235143a6c3377f49cbd35f18dc84dfa4baa7695c2a9b53d
+  queue-sidecar-image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:545c7414f9bc93763c5e41567a5fd6f3359d4d186700b8b28b1411e1c899a2c2
   _example: |-
     ################################
     #                              #
@@ -3967,6 +4861,7 @@ data:
     #
     # NOTE THAT THIS IS AN EXPERIMENTAL / ALPHA FEATURE
     concurrency-state-endpoint: ""
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -3981,6 +4876,7 @@ data:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -3989,10 +4885,9 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
   annotations:
-    knative.dev/example-checksum: "81552d0b"
+    knative.dev/example-checksum: "26c09de5"
 data:
   _example: |
     ################################
@@ -4011,16 +4906,6 @@ data:
     # to actually change the configuration.
 
     # Default value for domain.
-    # Although it will match all routes, it is the least-specific rule so it
-    # will only be used if no other domain matches.
-    example.com: |
-
-    # These are example settings of domain.
-    # example.org will be used for routes having app=nonprofit.
-    example.org: |
-      selector:
-        app: nonprofit
-
     # Routes having the cluster domain suffix (by default 'svc.cluster.local')
     # will not be exposed through Ingress. You can define your own label
     # selector to assign that domain suffix to your Route here, or you can set
@@ -4031,6 +4916,17 @@ data:
     svc.cluster.local: |
       selector:
         app: secret
+
+    # These are example settings of domain.
+    # example.com will be used for all routes, but it is the least-specific rule so it
+    # will only be used if no other domain matches.
+    example.com: |
+
+    # example.org will be used for routes having app=nonprofit.
+    example.org: |
+      selector:
+        app: nonprofit
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -4045,6 +4941,7 @@ data:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -4053,10 +4950,9 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
   annotations:
-    knative.dev/example-checksum: "d9e300ba"
+    knative.dev/example-checksum: "691a192e"
 data:
   _example: |-
     ################################
@@ -4085,6 +4981,12 @@ data:
     # WARNING: Cannot safely be disabled once enabled.
     # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-node-affinity
     kubernetes.podspec-affinity: "disabled"
+
+    # Indicates whether Kubernetes topologySpreadConstraints support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-topology-spread-constraints
+    kubernetes.podspec-topologyspreadconstraints: "disabled"
 
     # Indicates whether Kubernetes hostAliases support is enabled
     #
@@ -4116,6 +5018,18 @@ data:
     # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-runtime-class
     kubernetes.podspec-runtimeclassname: "disabled"
 
+    # Indicates whether Kubernetes DNSPolicy support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-dnspolicy
+    kubernetes.podspec-dnspolicy: "disabled"
+
+    # Indicates whether Kubernetes DNSConfig support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-dnsconfig
+    kubernetes.podspec-dnsconfig: "disabled"
+
     # This feature allows end-users to set a subset of fields on the Pod's SecurityContext
     #
     # When set to "enabled" or "allowed" it allows the following
@@ -4125,6 +5039,7 @@ data:
     # - RunAsNonRoot
     # - SupplementalGroups
     # - RunAsUser
+    # - SeccompProfile
     #
     # This feature flag should be used with caution as the PodSecurityContext
     # properties may have a side-effect on non-user sidecar containers that come
@@ -4176,7 +5091,7 @@ data:
     # Controls whether volume support for EmptyDir is enabled or not.
     # 1. Enabled: enabling EmptyDir volume support
     # 2. Disabled: disabling EmptyDir volume support
-    kubernetes.podspec-volumes-emptydir: "disabled"
+    kubernetes.podspec-volumes-emptydir: "enabled"
 
     # Controls whether init containers support is enabled or not.
     # 1. Enabled: enabling init containers support
@@ -4192,6 +5107,24 @@ data:
     # 1. Enabled: enabling write access for persistent volumes
     # 2. Disabled: disabling write access for persistent volumes
     kubernetes.podspec-persistent-volume-write: "disabled"
+
+    # Controls if the queue proxy podInfo feature is enabled, allowed or disabled
+    #
+    # This feature should be enabled/allowed when using queue proxy Options (Extensions)
+    # Enabling will mount a podInfo volume to the queue proxy container.
+    # The volume will contains an 'annotations' file (from the pod's annotation field).
+    # The annotations in this file include the Service annotations set by the client creating the service.
+    # If mounted, the annotations can be accessed by queue proxy extensions at /etc/podinfo/annnotations
+    #
+    # 1. "enabled": always mount a podInfo volume
+    # 2. "disabled": never mount a podInfo volume
+    # 3. "allowed": by default, do not mount a podInfo volume
+    #   However, a client may mount the podInfo volume on an individual Service by attaching
+    #   the following metadata annotation to the Service: "features.knative.dev/queueproxy-podinfo":"enabled".
+    #
+    # NOTE THAT THIS IS AN EXPERIMENTAL / ALPHA FEATURE
+    queueproxy.mount-podinfo: "disabled"
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -4206,6 +5139,7 @@ data:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -4214,10 +5148,9 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
   annotations:
-    knative.dev/example-checksum: "51b4d68a"
+    knative.dev/example-checksum: "aa3813a8"
 data:
   _example: |
     ################################
@@ -4234,7 +5167,6 @@ data:
     # These sample configuration options may be copied out of
     # this example block and unindented to be in the data block
     # to actually change the configuration.
-
 
     # ---------------------------------------
     # Garbage Collector Settings
@@ -4258,6 +5190,7 @@ data:
     #
     # Example config to immediately collect any inactive revision:
     #    min-non-active-revisions: "0"
+    #    max-non-active-revisions: "0"
     #    retain-since-create-time: "disabled"
     #    retain-since-last-active-time: "disabled"
     #
@@ -4266,7 +5199,7 @@ data:
     #     retain-since-last-active-time: "disabled"
     #     max-non-active-revisions: "10"
     #
-    # Example config to disable all GC:
+    # Example config to disable all garbage collection:
     #     retain-since-create-time: "disabled"
     #     retain-since-last-active-time: "disabled"
     #     max-non-active-revisions: "disabled"
@@ -4291,6 +5224,7 @@ data:
     # Maximum number of non-active revisions to retain
     # or "disabled" to disable any maximum limit.
     max-non-active-revisions: "1000"
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -4305,6 +5239,7 @@ data:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -4313,8 +5248,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
   annotations:
     knative.dev/example-checksum: "f4b71f57"
 data:
@@ -4352,6 +5286,7 @@ data:
     # bucket will take care of the reconciling for the keys partitioned into
     # that bucket.
     buckets: "1"
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -4366,17 +5301,18 @@ data:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-logging
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v1.2.5"
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.5"
+    app.kubernetes.io/component: logging
     app.kubernetes.io/name: knative-serving
   annotations:
-    knative.dev/example-checksum: "be93ff10"
+    knative.dev/example-checksum: "b0f3c6f2"
 data:
   _example: |
     ################################
@@ -4429,6 +5365,8 @@ data:
     loglevel.hpaautoscaler: "info"
     loglevel.net-certmanager-controller: "info"
     loglevel.net-istio-controller: "info"
+    loglevel.net-contour-controller: "info"
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -4443,6 +5381,7 @@ data:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -4450,10 +5389,10 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.8.5"
   annotations:
-    knative.dev/example-checksum: "6e2033e0"
+    knative.dev/example-checksum: "73d96d1b"
 data:
   _example: |
     ################################
@@ -4603,6 +5542,17 @@ data:
     # fronting Knative with an external loadbalancer that deals with TLS termination and
     # Knative doesn't know about that otherwise.
     default-external-scheme: "http"
+
+    # internal-encryption indicates whether internal traffic is encrypted or not.
+    # If this is "true", the following traffic are encrypted:
+    #  - ingress to activator
+    #  - ingress to queue-proxy
+    #  - activator to queue-proxy
+    #
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
+    internal-encryption: "false"
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -4617,6 +5567,7 @@ data:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -4624,8 +5575,8 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/version: "1.8.5"
   annotations:
     knative.dev/example-checksum: "fed4756e"
 data:
@@ -4710,6 +5661,7 @@ data:
     # enabled, the Knative Serving pods expose the profiling data on an alternate HTTP port 8008.
     # The HTTP context root for profiling is then /debug/pprof/.
     profiling.enable: "false"
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -4724,6 +5676,7 @@ data:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -4731,8 +5684,8 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: tracing
+    app.kubernetes.io/version: "1.8.5"
   annotations:
     knative.dev/example-checksum: "26614636"
 data:
@@ -4765,6 +5718,7 @@ data:
 
     # Percentage (0-1) of requests to trace
     sample-rate: "0.1"
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -4779,7 +5733,8 @@ data:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: autoscaling/v2beta2
+
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: activator
@@ -4787,8 +5742,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -4816,13 +5770,13 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 spec:
   minAvailable: 80%
   selector:
     matchLabels:
       app: activator
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -4837,6 +5791,7 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -4844,9 +5799,8 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: "v1.2.5"
 spec:
   selector:
     matchLabels:
@@ -4861,15 +5815,14 @@ spec:
         role: activator
         app.kubernetes.io/component: activator
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.2.5"
-        serving.knative.dev/release: "v1.2.5"
+        app.kubernetes.io/version: "1.8.5"
     spec:
       serviceAccountName: controller
       containers:
         - name: activator
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:93ff6e69357785ff97806945b284cbd1d37e50402b876a320645be8877c0d7b7
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:dfe093337af4487ef5ad58a20f31b523da70aa91e21750725db34f11a7d643fd
           # The numbers are based on performance test results from
           # https://github.com/knative/serving/issues/1625#issuecomment-511930023
           resources:
@@ -4908,7 +5861,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -4952,9 +5907,8 @@ metadata:
   labels:
     app: activator
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: "v1.2.5"
 spec:
   selector:
     app: activator
@@ -4972,7 +5926,11 @@ spec:
     - name: http2
       port: 81
       targetPort: 8013
+    - name: https
+      port: 443
+      targetPort: 8112
   type: ClusterIP
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -4987,6 +5945,7 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -4995,8 +5954,7 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 spec:
   replicas: 1
   selector:
@@ -5014,8 +5972,7 @@ spec:
         app: autoscaler
         app.kubernetes.io/component: autoscaler
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.2.5"
-        serving.knative.dev/release: "v1.2.5"
+        app.kubernetes.io/version: "1.8.5"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5032,7 +5989,7 @@ spec:
         - name: autoscaler
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:007820fdb75b60e6fd5a25e65fd6ad9744082a6bf195d72795561c91b425d016
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:53f24d86665c1db4767eefd4745cfbff6d7cae87de4f0fddf03d2e522ca20c6a
           resources:
             requests:
               cpu: 100m
@@ -5066,7 +6023,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -5095,8 +6054,7 @@ metadata:
     app: autoscaler
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -5113,6 +6071,7 @@ spec:
       targetPort: 8080
   selector:
     app: autoscaler
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -5127,6 +6086,7 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -5135,8 +6095,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 spec:
   selector:
     matchLabels:
@@ -5149,8 +6108,7 @@ spec:
         app: controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.2.5"
-        serving.knative.dev/release: "v1.2.5"
+        app.kubernetes.io/version: "1.8.5"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5167,7 +6125,7 @@ spec:
         - name: controller
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:75cfdcfa050af9522e798e820ba5483b9093de1ce520207a3fedf112d73a4686
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:9d84d63307851a2581b787ae6a3293180e78665ced64111dc924d7a258f40f59
           resources:
             requests:
               cpu: 100m
@@ -5197,7 +6155,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -5211,8 +6171,7 @@ metadata:
     app: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
   name: controller
   namespace: knative-serving
 spec:
@@ -5226,6 +6185,7 @@ spec:
       targetPort: 8008
   selector:
     app: controller
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -5240,6 +6200,7 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -5248,8 +6209,7 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 spec:
   selector:
     matchLabels:
@@ -5262,8 +6222,7 @@ spec:
         app: domain-mapping
         app.kubernetes.io/component: domain-mapping
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.2.5"
-        serving.knative.dev/release: "v1.2.5"
+        app.kubernetes.io/version: "1.8.5"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5280,7 +6239,7 @@ spec:
         - name: domain-mapping
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping@sha256:23baa19322320f25a462568eded1276601ef67194883db9211e1ea24f21a0beb
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping@sha256:9e77a8e1d9b755ff160cc7784a7f95fae12f1378c2eb00dcbb3c0343a92e73bb
           resources:
             requests:
               cpu: 30m
@@ -5306,12 +6265,15 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
             - name: profiling
               containerPort: 8008
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -5326,6 +6288,7 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -5334,8 +6297,7 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 spec:
   selector:
     matchLabels:
@@ -5350,8 +6312,7 @@ spec:
         role: domainmapping-webhook
         app.kubernetes.io/component: domain-mapping
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.2.5"
-        serving.knative.dev/release: "v1.2.5"
+        app.kubernetes.io/version: "1.8.5"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5368,7 +6329,7 @@ spec:
         - name: domainmapping-webhook
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping-webhook@sha256:847bb97e38440c71cb4bcc3e430743e18b328ad1e168b6fca35b10353b9a2c22
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping-webhook@sha256:ece64767c8fd47a8e929631714fe8b89b515c508c19a6dd698f80d6cf69a1e4f
           resources:
             requests:
               cpu: 100m
@@ -5400,7 +6361,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -5437,8 +6400,7 @@ metadata:
     role: domainmapping-webhook
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
   name: domainmapping-webhook
   namespace: knative-serving
 spec:
@@ -5455,6 +6417,7 @@ spec:
       targetPort: 8443
   selector:
     role: domainmapping-webhook
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -5469,7 +6432,8 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: autoscaling/v2beta2
+
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: webhook
@@ -5477,8 +6441,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -5504,13 +6467,13 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 spec:
   minAvailable: 80%
   selector:
     matchLabels:
       app: webhook
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -5525,15 +6488,15 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v1.2.5"
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -5547,9 +6510,7 @@ spec:
       labels:
         app: webhook
         role: webhook
-        serving.knative.dev/release: "v1.2.5"
-        app.kubernetes.io/component: webhook
-        app.kubernetes.io/version: "1.2.5"
+        app.kubernetes.io/version: "1.8.5"
         app.kubernetes.io/name: knative-serving
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
@@ -5567,7 +6528,7 @@ spec:
         - name: webhook
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:9084ea8498eae3c6c4364a397d66516a25e48488f4a9871ef765fa554ba483f0
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:2d720d2a433d1dd2bcbcdae6ac2433fa01a79adff0752e9212389fcd7cada070
           resources:
             requests:
               cpu: 100m
@@ -5601,7 +6562,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -5636,9 +6599,8 @@ kind: Service
 metadata:
   labels:
     role: webhook
-    serving.knative.dev/release: "v1.2.5"
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     app.kubernetes.io/name: knative-serving
   name: webhook
   namespace: knative-serving
@@ -5656,6 +6618,7 @@ spec:
       targetPort: 8443
   selector:
     role: webhook
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -5670,6 +6633,7 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -5677,8 +6641,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -5688,11 +6651,16 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     name: config.webhook.serving.knative.dev
-    namespaceSelector:
+    objectSelector:
       matchExpressions:
-        - key: serving.knative.dev/release
-          operator: Exists
+        - key: app.kubernetes.io/name
+          operator: In
+          values: ["knative-serving"]
+        - key: app.kubernetes.io/component
+          operator: In
+          values: ["autoscaler", "controller", "logging", "networking", "observability", "tracing"]
     timeoutSeconds: 10
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -5707,6 +6675,7 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -5714,8 +6683,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -5747,6 +6715,7 @@ webhooks:
           - revisions
           - routes
           - services
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -5761,6 +6730,7 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -5768,8 +6738,7 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -5784,14 +6753,15 @@ webhooks:
       - apiGroups:
           - serving.knative.dev
         apiVersions:
-          - v1alpha1
-          - v1beta1
+          - "*"
         operations:
           - CREATE
           - UPDATE
         scope: "*"
         resources:
           - domainmappings
+          - domainmappings/status
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -5806,6 +6776,7 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5814,9 +6785,9 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 # The data is populated at install time.
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -5831,6 +6802,7 @@ metadata:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -5838,8 +6810,7 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -5854,8 +6825,7 @@ webhooks:
       - apiGroups:
           - serving.knative.dev
         apiVersions:
-          - v1alpha1
-          - v1beta1
+          - "*"
         operations:
           - CREATE
           - UPDATE
@@ -5863,6 +6833,8 @@ webhooks:
         scope: "*"
         resources:
           - domainmappings
+          - domainmappings/status
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -5877,6 +6849,7 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -5884,8 +6857,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -5918,6 +6890,7 @@ webhooks:
           - revisions
           - routes
           - services
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -5932,6 +6905,7 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5940,6 +6914,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
 # The data is populated at install time.
+
+---

--- a/kubeflow/common/knative/knative-1-8-5/serving-crds.yaml
+++ b/kubeflow/common/knative/knative-1-8-5/serving-crds.yaml
@@ -11,14 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -30,12 +31,99 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: Certificate is responsible for provisioning a SSL certificate for the given hosts. It is a Knative abstraction for various SSL certificate provisioning solutions (such as cert-manager or self-signed SSL certificate).
           type: object
-          # this is a work around so we don't need to flush out the
-          # schema for each version at this time
-          #
-          # see issue: https://github.com/knative/serving/issues/912
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'Spec is the desired state of the Certificate. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              required:
+                - dnsNames
+                - secretName
+              properties:
+                dnsNames:
+                  description: DNSNames is a list of DNS names the Certificate could support. The wildcard format of DNSNames (e.g. *.default.example.com) is supported.
+                  type: array
+                  items:
+                    type: string
+                secretName:
+                  description: SecretName is the name of the secret resource to store the SSL certificate in.
+                  type: string
+            status:
+              description: 'Status is the current state of the Certificate. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                http01Challenges:
+                  description: HTTP01Challenges is a list of HTTP01 challenges that need to be fulfilled in order to get the TLS certificate..
+                  type: array
+                  items:
+                    description: HTTP01Challenge defines the status of a HTTP01 challenge that a certificate needs to fulfill.
+                    type: object
+                    properties:
+                      serviceName:
+                        description: ServiceName is the name of the service to serve HTTP01 challenge requests.
+                        type: string
+                      serviceNamespace:
+                        description: ServiceNamespace is the namespace of the service to serve HTTP01 challenge requests.
+                        type: string
+                      servicePort:
+                        description: ServicePort is the port of the service to serve HTTP01 challenge requests.
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
+                      url:
+                        description: URL is the URL that the HTTP01 challenge is expected to serve on.
+                        type: string
+                notAfter:
+                  description: The expiration time of the TLS certificate stored in the secret named by this resource in spec.secretName.
+                  type: string
+                  format: date-time
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
       additionalPrinterColumns:
         - name: Ready
           type: string
@@ -53,6 +141,7 @@ spec:
     shortNames:
       - kcert
   scope: Namespaced
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -69,14 +158,14 @@ spec:
 # limitations under the License.
 
 # Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: configurations.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -159,6 +248,10 @@ spec:
                       required:
                         - containers
                       properties:
+                        affinity:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         automountServiceAccountToken:
                           description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                           type: boolean
@@ -174,12 +267,12 @@ spec:
                             type: object
                             properties:
                               args:
-                                description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                 type: array
                                 items:
                                   type: string
                               command:
-                                description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                 type: array
                                 items:
                                   type: string
@@ -217,6 +310,17 @@ spec:
                                             optional:
                                               description: Specify whether the ConfigMap or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           description: Selects a key of a secret in the pod's namespace
                                           type: object
@@ -232,7 +336,7 @@ spec:
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
                                               type: boolean
-                                      x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                               envFrom:
                                 description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                 type: array
@@ -250,6 +354,7 @@ spec:
                                         optional:
                                           description: Specify whether the ConfigMap must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
@@ -263,8 +368,9 @@ spec:
                                         optional:
                                           description: Specify whether the Secret must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                               image:
-                                description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                                description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                 type: string
                               imagePullPolicy:
                                 description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -274,7 +380,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -312,10 +418,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -329,13 +440,18 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: TCPSocket specifies an action involving a TCP port.
                                     type: object
                                     properties:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -344,7 +460,7 @@ spec:
                                 description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                 type: string
                               ports:
-                                description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                                description: List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
                                 type: array
                                 items:
                                   description: ContainerPort represents a network port in a single container.
@@ -363,7 +479,6 @@ spec:
                                       description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                       type: string
                                       default: TCP
-                                  x-kubernetes-preserve-unknown-fields: true
                                 x-kubernetes-list-map-keys:
                                   - containerPort
                                   - protocol
@@ -373,7 +488,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -411,10 +526,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -428,13 +548,18 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: TCPSocket specifies an action involving a TCP port.
                                     type: object
                                     properties:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -465,25 +590,39 @@ spec:
                                 description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                 type: object
                                 properties:
+                                  allowPrivilegeEscalation:
+                                    description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.'
+                                    type: boolean
                                   capabilities:
-                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                                     type: object
                                     properties:
+                                      add:
+                                        description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
                                       drop:
                                         description: Removed capabilities
                                         type: array
                                         items:
                                           description: Capability represent POSIX capabilities type
                                           type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   readOnlyRootFilesystem:
-                                    description: Whether this container has a read-only root filesystem. Default is false.
+                                    description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
-                                  runAsUser:
-                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
-                                x-kubernetes-preserve-unknown-fields: true
+                                  runAsNonRoot:
+                                    description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string
@@ -515,12 +654,29 @@ spec:
                               workingDir:
                                 description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                        dnsConfig:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        dnsPolicy:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                          type: string
                         enableServiceLinks:
-                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
                           type: boolean
+                        hostAliases:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        idleTimeoutSeconds:
+                          description: IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed to stay open while not receiving any bytes from the user's application. If unspecified, a system default will be provided.
+                          type: integer
+                          format: int64
                         imagePullSecrets:
-                          description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                          description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                           type: array
                           items:
                             description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
@@ -529,13 +685,60 @@ spec:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
+                            x-kubernetes-map-type: atomic
+                        initContainers:
+                          description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        nodeSelector:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          x-kubernetes-map-type: atomic
+                        priorityClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        responseStartTimeoutSeconds:
+                          description: ResponseStartTimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin sending any network traffic.
+                          type: integer
+                          format: int64
+                        runtimeClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        schedulerName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        securityContext:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         serviceAccountName:
                           description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                           type: string
                         timeoutSeconds:
-                          description: TimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (send network traffic). If unspecified, a system default will be provided.
+                          description: TimeoutSeconds is the maximum duration in seconds that the request instance is allowed to respond to a request. If unspecified, a system default will be provided.
                           type: integer
                           format: int64
+                        tolerations:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        topologySpreadConstraints:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         volumes:
                           description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                           type: array
@@ -546,15 +749,15 @@ spec:
                               - name
                             properties:
                               configMap:
-                                description: ConfigMap represents a configMap that should populate this volume
+                                description: configMap represents a configMap that should populate this volume
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                     type: integer
                                     format: int32
                                   items:
-                                    description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                    description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                     type: array
                                     items:
                                       description: Maps a string key to a path within a volume.
@@ -564,45 +767,54 @@ spec:
                                         - path
                                       properties:
                                         key:
-                                          description: The key to project.
+                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                           type: integer
                                           format: int32
                                         path:
-                                          description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                           type: string
                                   name:
                                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its keys must be defined
+                                    description: optional specify whether the ConfigMap or its keys must be defined
                                     type: boolean
+                                x-kubernetes-map-type: atomic
+                              emptyDir:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               name:
-                                description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
+                              persistentVolumeClaim:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               projected:
-                                description: Items for all in one resources secrets, configmaps, and downward API
+                                description: projected items for all in one resources secrets, configmaps, and downward API
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                    description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                     type: integer
                                     format: int32
                                   sources:
-                                    description: list of volume projections
+                                    description: sources is the list of volume projections
                                     type: array
                                     items:
                                       description: Projection that may be projected along with other supported volume types
                                       type: object
                                       properties:
                                         configMap:
-                                          description: information about the configMap data to project
+                                          description: configMap information about the configMap data to project
                                           type: object
                                           properties:
                                             items:
-                                              description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                              description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                               type: array
                                               items:
                                                 description: Maps a string key to a path within a volume.
@@ -612,27 +824,28 @@ spec:
                                                   - path
                                                 properties:
                                                   key:
-                                                    description: The key to project.
+                                                    description: key is the key to project.
                                                     type: string
                                                   mode:
-                                                    description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                    description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                     type: integer
                                                     format: int32
                                                   path:
-                                                    description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                    description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                     type: string
                                             name:
                                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap or its keys must be defined
+                                              description: optional specify whether the ConfigMap or its keys must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         secret:
-                                          description: information about the secret data to project
+                                          description: secret information about the secret data to project
                                           type: object
                                           properties:
                                             items:
-                                              description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                              description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                               type: array
                                               items:
                                                 description: Maps a string key to a path within a volume.
@@ -642,47 +855,48 @@ spec:
                                                   - path
                                                 properties:
                                                   key:
-                                                    description: The key to project.
+                                                    description: key is the key to project.
                                                     type: string
                                                   mode:
-                                                    description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                    description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                     type: integer
                                                     format: int32
                                                   path:
-                                                    description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                    description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                     type: string
                                             name:
                                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret or its key must be defined
+                                              description: optional field specify whether the Secret or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         serviceAccountToken:
-                                          description: information about the serviceAccountToken data to project
+                                          description: serviceAccountToken is information about the serviceAccountToken data to project
                                           type: object
                                           required:
                                             - path
                                           properties:
                                             audience:
-                                              description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                              description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                               type: string
                                             expirationSeconds:
-                                              description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                              description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                               type: integer
                                               format: int64
                                             path:
-                                              description: Path is the path relative to the mount point of the file to project the token into.
+                                              description: path is the path relative to the mount point of the file to project the token into.
                                               type: string
                               secret:
-                                description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                     type: integer
                                     format: int32
                                   items:
-                                    description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                    description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                     type: array
                                     items:
                                       description: Maps a string key to a path within a volume.
@@ -692,23 +906,21 @@ spec:
                                         - path
                                       properties:
                                         key:
-                                          description: The key to project.
+                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                           type: integer
                                           format: int32
                                         path:
-                                          description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                           type: string
                                   optional:
-                                    description: Specify whether the Secret or its keys must be defined
+                                    description: optional field specify whether the Secret or its keys must be defined
                                     type: boolean
                                   secretName:
-                                    description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
-                            x-kubernetes-preserve-unknown-fields: true
-                      x-kubernetes-preserve-unknown-fields: true
             status:
               description: ConfigurationStatus communicates the observed state of the Configuration (from the controller).
               type: object
@@ -731,7 +943,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -757,6 +968,7 @@ spec:
                   description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                   type: integer
                   format: int64
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -771,14 +983,15 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterdomainclaims.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -790,12 +1003,26 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: ClusterDomainClaim is a cluster-wide reservation for a particular domain name.
           type: object
-          # this is a work around so we don't need to flush out the
-          # schema for each version at this time
-          #
-          # see issue: https://github.com/knative/serving/issues/912
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'Spec is the desired state of the ClusterDomainClaim. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              required:
+                - namespace
+              properties:
+                namespace:
+                  description: Namespace is the namespace which is allowed to create a DomainMapping using this ClusterDomainClaim's name.
+                  type: string
   names:
     kind: ClusterDomainClaim
     plural: clusterdomainclaims
@@ -806,6 +1033,7 @@ spec:
     shortNames:
       - cdc
   scope: Cluster
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -820,14 +1048,14 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: domainmappings.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -925,7 +1153,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -1031,7 +1258,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -1075,6 +1301,7 @@ spec:
     shortNames:
       - dm
   scope: Namespaced
+
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -1089,14 +1316,15 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ingresses.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1108,12 +1336,212 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable URLs, load balance traffic, offer name based virtual hosting, etc. \n This is heavily based on K8s Ingress https://godoc.org/k8s.io/api/networking/v1beta1#Ingress which some highlighted modifications."
           type: object
-          # this is a work around so we don't need to flush out the
-          # schema for each version at this time
-          #
-          # see issue: https://github.com/knative/serving/issues/912
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'Spec is the desired state of the Ingress. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              properties:
+                httpOption:
+                  description: 'HTTPOption is the option of HTTP. It has the following two values: `HTTPOptionEnabled`, `HTTPOptionRedirected`'
+                  type: string
+                rules:
+                  description: A list of host rules used to configure the Ingress.
+                  type: array
+                  items:
+                    description: IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.
+                    type: object
+                    properties:
+                      hosts:
+                        description: 'Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently a rule value can only apply to the IP in the Spec of the parent . 2. The `:` delimiter is not respected because ports are not allowed. Currently the port of an Ingress is implicitly :80 for http and :443 for https. Both these may change in the future. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue. If multiple matching Hosts were provided, the first rule will take precedent.'
+                        type: array
+                        items:
+                          type: string
+                      http:
+                        description: HTTP represents a rule to apply against incoming requests. If the rule is satisfied, the request is routed to the specified backend.
+                        type: object
+                        required:
+                          - paths
+                        properties:
+                          paths:
+                            description: "A collection of paths that map requests to backends. \n If they are multiple matching paths, the first match takes precedence."
+                            type: array
+                            items:
+                              description: HTTPIngressPath associates a path regex with a backend. Incoming URLs matching the path are forwarded to the backend.
+                              type: object
+                              required:
+                                - splits
+                              properties:
+                                appendHeaders:
+                                  description: "AppendHeaders allow specifying additional HTTP headers to add before forwarding a request to the destination service. \n NOTE: This differs from K8s Ingress which doesn't allow header appending."
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                headers:
+                                  description: Headers defines header matching rules which is a map from a header name to HeaderMatch which specify a matching condition. When a request matched with all the header matching rules, the request is routed by the corresponding ingress rule. If it is empty, the headers are not used for matching
+                                  type: object
+                                  additionalProperties:
+                                    description: HeaderMatch represents a matching value of Headers in HTTPIngressPath. Currently, only the exact matching is supported.
+                                    type: object
+                                    required:
+                                      - exact
+                                    properties:
+                                      exact:
+                                        type: string
+                                path:
+                                  description: Path represents a literal prefix to which this rule should apply. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.
+                                  type: string
+                                rewriteHost:
+                                  description: "RewriteHost rewrites the incoming request's host header. \n This field is currently experimental and not supported by all Ingress implementations."
+                                  type: string
+                                splits:
+                                  description: Splits defines the referenced service endpoints to which the traffic will be forwarded to.
+                                  type: array
+                                  items:
+                                    description: IngressBackendSplit describes all endpoints for a given service and port.
+                                    type: object
+                                    required:
+                                      - serviceName
+                                      - serviceNamespace
+                                      - servicePort
+                                    properties:
+                                      appendHeaders:
+                                        description: "AppendHeaders allow specifying additional HTTP headers to add before forwarding a request to the destination service. \n NOTE: This differs from K8s Ingress which doesn't allow header appending."
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      percent:
+                                        description: "Specifies the split percentage, a number between 0 and 100.  If only one split is specified, we default to 100. \n NOTE: This differs from K8s Ingress to allow percentage split."
+                                        type: integer
+                                      serviceName:
+                                        description: Specifies the name of the referenced service.
+                                        type: string
+                                      serviceNamespace:
+                                        description: "Specifies the namespace of the referenced service. \n NOTE: This differs from K8s Ingress to allow routing to different namespaces."
+                                        type: string
+                                      servicePort:
+                                        description: Specifies the port of the referenced service.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                      visibility:
+                        description: Visibility signifies whether this rule should `ClusterLocal`. If it's not specified then it defaults to `ExternalIP`.
+                        type: string
+                tls:
+                  description: 'TLS configuration. Currently Ingress only supports a single TLS port: 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.'
+                  type: array
+                  items:
+                    description: IngressTLS describes the transport layer security associated with an Ingress.
+                    type: object
+                    properties:
+                      hosts:
+                        description: Hosts is a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.
+                        type: array
+                        items:
+                          type: string
+                      secretName:
+                        description: SecretName is the name of the secret used to terminate SSL traffic.
+                        type: string
+                      secretNamespace:
+                        description: SecretNamespace is the namespace of the secret used to terminate SSL traffic. If not set the namespace should be assumed to be the same as the Ingress. If set the secret should have the same namespace as the Ingress otherwise the behaviour is undefined and not supported.
+                        type: string
+            status:
+              description: 'Status is the current state of the Ingress. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
+                privateLoadBalancer:
+                  description: PrivateLoadBalancer contains the current status of the load-balancer.
+                  type: object
+                  properties:
+                    ingress:
+                      description: Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
+                      type: array
+                      items:
+                        description: 'LoadBalancerIngressStatus represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.'
+                        type: object
+                        properties:
+                          domain:
+                            description: Domain is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)
+                            type: string
+                          domainInternal:
+                            description: "DomainInternal is set if there is a cluster-local DNS name to access the Ingress. \n NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local DNS name to allow routing in case of not having a mesh."
+                            type: string
+                          ip:
+                            description: IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)
+                            type: string
+                          meshOnly:
+                            description: MeshOnly is set if the Ingress is only load-balanced through a Service mesh.
+                            type: boolean
+                publicLoadBalancer:
+                  description: PublicLoadBalancer contains the current status of the load-balancer.
+                  type: object
+                  properties:
+                    ingress:
+                      description: Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
+                      type: array
+                      items:
+                        description: 'LoadBalancerIngressStatus represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.'
+                        type: object
+                        properties:
+                          domain:
+                            description: Domain is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)
+                            type: string
+                          domainInternal:
+                            description: "DomainInternal is set if there is a cluster-local DNS name to access the Ingress. \n NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local DNS name to allow routing in case of not having a mesh."
+                            type: string
+                          ip:
+                            description: IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)
+                            type: string
+                          meshOnly:
+                            description: MeshOnly is set if the Ingress is only load-balanced through a Service mesh.
+                            type: boolean
       additionalPrinterColumns:
         - name: Ready
           type: string
@@ -1132,6 +1560,7 @@ spec:
       - kingress
       - king
   scope: Namespaced
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -1148,14 +1577,14 @@ spec:
 # limitations under the License.
 
 # Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1234,7 +1663,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -1254,6 +1682,7 @@ spec:
                   description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                   type: integer
                   format: int64
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -1270,14 +1699,14 @@ spec:
 # limitations under the License.
 
 # Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1313,7 +1742,7 @@ spec:
           jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
       schema:
         openAPIV3Schema:
-          description: 'PodAutoscaler is a Knative abstraction that encapsulates the interface by which Knative components instantiate autoscalers.  This definition is an abstraction that may be backed by multiple definitions.  For more information, see the Knative Pluggability presentation: https://docs.google.com/presentation/d/10KWynvAJYuOEWy69VBa6bHJVCqIsz1TNdEKosNvcpPY/edit'
+          description: 'PodAutoscaler is a Knative abstraction that encapsulates the interface by which Knative components instantiate autoscalers.  This definition is an abstraction that may be backed by multiple definitions.  For more information, see the Knative Pluggability presentation: https://docs.google.com/presentation/d/19vW9HFZ6Puxt31biNZF3uLRejDmu82rxJIk1cWmxF7w/edit'
           type: object
           properties:
             apiVersion:
@@ -1354,6 +1783,7 @@ spec:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
+                  x-kubernetes-map-type: atomic
             status:
               description: Status communicates the observed state of the PodAutoscaler (from the controller).
               type: object
@@ -1383,7 +1813,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -1413,6 +1842,7 @@ spec:
                 serviceName:
                   description: ServiceName is the K8s Service name that serves the revision, scaled by this PA. The service is created and owned by the ServerlessService object owned by this PA.
                   type: string
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -1429,14 +1859,14 @@ spec:
 # limitations under the License.
 
 # Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: revisions.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -1498,6 +1928,10 @@ spec:
               required:
                 - containers
               properties:
+                affinity:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 automountServiceAccountToken:
                   description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                   type: boolean
@@ -1513,12 +1947,12 @@ spec:
                     type: object
                     properties:
                       args:
-                        description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                         type: array
                         items:
                           type: string
                       command:
-                        description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                         type: array
                         items:
                           type: string
@@ -1556,6 +1990,17 @@ spec:
                                     optional:
                                       description: Specify whether the ConfigMap or its key must be defined
                                       type: boolean
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's namespace
                                   type: object
@@ -1571,7 +2016,7 @@ spec:
                                     optional:
                                       description: Specify whether the Secret or its key must be defined
                                       type: boolean
-                              x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
                       envFrom:
                         description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                         type: array
@@ -1589,6 +2034,7 @@ spec:
                                 optional:
                                   description: Specify whether the ConfigMap must be defined
                                   type: boolean
+                              x-kubernetes-map-type: atomic
                             prefix:
                               description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                               type: string
@@ -1602,8 +2048,9 @@ spec:
                                 optional:
                                   description: Specify whether the Secret must be defined
                                   type: boolean
+                              x-kubernetes-map-type: atomic
                       image:
-                        description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                        description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                         type: string
                       imagePullPolicy:
                         description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -1613,7 +2060,7 @@ spec:
                         type: object
                         properties:
                           exec:
-                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                            description: Exec specifies the action to take.
                             type: object
                             properties:
                               command:
@@ -1651,10 +2098,15 @@ spec:
                               path:
                                 description: Path to access on the HTTP server.
                                 type: string
+                              port:
+                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host. Defaults to HTTP.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
                           initialDelaySeconds:
                             description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -1668,13 +2120,18 @@ spec:
                             type: integer
                             format: int32
                           tcpSocket:
-                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                            description: TCPSocket specifies an action involving a TCP port.
                             type: object
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                              port:
+                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                           timeoutSeconds:
                             description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -1683,7 +2140,7 @@ spec:
                         description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                         type: string
                       ports:
-                        description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                        description: List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
                         type: array
                         items:
                           description: ContainerPort represents a network port in a single container.
@@ -1702,7 +2159,6 @@ spec:
                               description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                               type: string
                               default: TCP
-                          x-kubernetes-preserve-unknown-fields: true
                         x-kubernetes-list-map-keys:
                           - containerPort
                           - protocol
@@ -1712,7 +2168,7 @@ spec:
                         type: object
                         properties:
                           exec:
-                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                            description: Exec specifies the action to take.
                             type: object
                             properties:
                               command:
@@ -1750,10 +2206,15 @@ spec:
                               path:
                                 description: Path to access on the HTTP server.
                                 type: string
+                              port:
+                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host. Defaults to HTTP.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
                           initialDelaySeconds:
                             description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -1767,13 +2228,18 @@ spec:
                             type: integer
                             format: int32
                           tcpSocket:
-                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                            description: TCPSocket specifies an action involving a TCP port.
                             type: object
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                              port:
+                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                           timeoutSeconds:
                             description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -1804,25 +2270,39 @@ spec:
                         description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                         type: object
                         properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.'
+                            type: boolean
                           capabilities:
-                            description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                            description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                             type: object
                             properties:
+                              add:
+                                description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                type: array
+                                items:
+                                  description: Capability represent POSIX capabilities type
+                                  type: string
                               drop:
                                 description: Removed capabilities
                                 type: array
                                 items:
                                   description: Capability represent POSIX capabilities type
                                   type: string
-                            x-kubernetes-preserve-unknown-fields: true
                           readOnlyRootFilesystem:
-                            description: Whether this container has a read-only root filesystem. Default is false.
+                            description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
-                          runAsUser:
-                            description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             type: integer
                             format: int64
-                        x-kubernetes-preserve-unknown-fields: true
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                            type: integer
+                            format: int64
                       terminationMessagePath:
                         description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                         type: string
@@ -1854,12 +2334,29 @@ spec:
                       workingDir:
                         description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                         type: string
-                    x-kubernetes-preserve-unknown-fields: true
+                dnsConfig:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                dnsPolicy:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                  type: string
                 enableServiceLinks:
-                  description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                  description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
                   type: boolean
+                hostAliases:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                idleTimeoutSeconds:
+                  description: IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed to stay open while not receiving any bytes from the user's application. If unspecified, a system default will be provided.
+                  type: integer
+                  format: int64
                 imagePullSecrets:
-                  description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                  description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                   type: array
                   items:
                     description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
@@ -1868,13 +2365,60 @@ spec:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
+                    x-kubernetes-map-type: atomic
+                initContainers:
+                  description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                nodeSelector:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-map-type: atomic
+                priorityClassName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                responseStartTimeoutSeconds:
+                  description: ResponseStartTimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin sending any network traffic.
+                  type: integer
+                  format: int64
+                runtimeClassName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                schedulerName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                securityContext:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 serviceAccountName:
                   description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                   type: string
                 timeoutSeconds:
-                  description: TimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (send network traffic). If unspecified, a system default will be provided.
+                  description: TimeoutSeconds is the maximum duration in seconds that the request instance is allowed to respond to a request. If unspecified, a system default will be provided.
                   type: integer
                   format: int64
+                tolerations:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                topologySpreadConstraints:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 volumes:
                   description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                   type: array
@@ -1885,15 +2429,15 @@ spec:
                       - name
                     properties:
                       configMap:
-                        description: ConfigMap represents a configMap that should populate this volume
+                        description: configMap represents a configMap that should populate this volume
                         type: object
                         properties:
                           defaultMode:
-                            description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                            description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                             type: integer
                             format: int32
                           items:
-                            description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                             type: array
                             items:
                               description: Maps a string key to a path within a volume.
@@ -1903,45 +2447,54 @@ spec:
                                 - path
                               properties:
                                 key:
-                                  description: The key to project.
+                                  description: key is the key to project.
                                   type: string
                                 mode:
-                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   type: integer
                                   format: int32
                                 path:
-                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                   type: string
                           name:
                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the ConfigMap or its keys must be defined
+                            description: optional specify whether the ConfigMap or its keys must be defined
                             type: boolean
+                        x-kubernetes-map-type: atomic
+                      emptyDir:
+                        description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       name:
-                        description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
+                      persistentVolumeClaim:
+                        description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       projected:
-                        description: Items for all in one resources secrets, configmaps, and downward API
+                        description: projected items for all in one resources secrets, configmaps, and downward API
                         type: object
                         properties:
                           defaultMode:
-                            description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                            description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                             type: integer
                             format: int32
                           sources:
-                            description: list of volume projections
+                            description: sources is the list of volume projections
                             type: array
                             items:
                               description: Projection that may be projected along with other supported volume types
                               type: object
                               properties:
                                 configMap:
-                                  description: information about the configMap data to project
+                                  description: configMap information about the configMap data to project
                                   type: object
                                   properties:
                                     items:
-                                      description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                       type: array
                                       items:
                                         description: Maps a string key to a path within a volume.
@@ -1951,27 +2504,28 @@ spec:
                                           - path
                                         properties:
                                           key:
-                                            description: The key to project.
+                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                             type: integer
                                             format: int32
                                           path:
-                                            description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                             type: string
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or its keys must be defined
+                                      description: optional specify whether the ConfigMap or its keys must be defined
                                       type: boolean
+                                  x-kubernetes-map-type: atomic
                                 secret:
-                                  description: information about the secret data to project
+                                  description: secret information about the secret data to project
                                   type: object
                                   properties:
                                     items:
-                                      description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                       type: array
                                       items:
                                         description: Maps a string key to a path within a volume.
@@ -1981,47 +2535,48 @@ spec:
                                           - path
                                         properties:
                                           key:
-                                            description: The key to project.
+                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                             type: integer
                                             format: int32
                                           path:
-                                            description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                             type: string
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its key must be defined
+                                      description: optional field specify whether the Secret or its key must be defined
                                       type: boolean
+                                  x-kubernetes-map-type: atomic
                                 serviceAccountToken:
-                                  description: information about the serviceAccountToken data to project
+                                  description: serviceAccountToken is information about the serviceAccountToken data to project
                                   type: object
                                   required:
                                     - path
                                   properties:
                                     audience:
-                                      description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                      description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                       type: string
                                     expirationSeconds:
-                                      description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                      description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                       type: integer
                                       format: int64
                                     path:
-                                      description: Path is the path relative to the mount point of the file to project the token into.
+                                      description: path is the path relative to the mount point of the file to project the token into.
                                       type: string
                       secret:
-                        description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                         type: object
                         properties:
                           defaultMode:
-                            description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                            description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                             type: integer
                             format: int32
                           items:
-                            description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                            description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                             type: array
                             items:
                               description: Maps a string key to a path within a volume.
@@ -2031,23 +2586,21 @@ spec:
                                 - path
                               properties:
                                 key:
-                                  description: The key to project.
+                                  description: key is the key to project.
                                   type: string
                                 mode:
-                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   type: integer
                                   format: int32
                                 path:
-                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                   type: string
                           optional:
-                            description: Specify whether the Secret or its keys must be defined
+                            description: optional field specify whether the Secret or its keys must be defined
                             type: boolean
                           secretName:
-                            description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                             type: string
-                    x-kubernetes-preserve-unknown-fields: true
-              x-kubernetes-preserve-unknown-fields: true
             status:
               description: RevisionStatus communicates the observed state of the Revision (from the controller).
               type: object
@@ -2074,7 +2627,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -2123,6 +2675,7 @@ spec:
                   description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                   type: integer
                   format: int64
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -2139,14 +2692,14 @@ spec:
 # limitations under the License.
 
 # Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: routes.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -2209,7 +2762,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:
@@ -2249,7 +2802,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -2283,7 +2835,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:
@@ -2298,6 +2850,7 @@ spec:
                 url:
                   description: URL holds the url that will distribute traffic over the provided traffic targets. It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}
                   type: string
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -2312,14 +2865,15 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: serverlessservices.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2331,12 +2885,107 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: 'ServerlessService is a proxy for the K8s service objects containing the endpoints for the revision, whether those are endpoints of the activator or revision pods. See: https://knative.page.link/naxz for details.'
           type: object
-          # this is a work around so we don't need to flush out the
-          # schema for each version at this time
-          #
-          # see issue: https://github.com/knative/serving/issues/912
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'Spec is the desired state of the ServerlessService. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              required:
+                - objectRef
+                - protocolType
+              properties:
+                mode:
+                  description: Mode describes the mode of operation of the ServerlessService.
+                  type: string
+                numActivators:
+                  description: NumActivators contains number of Activators that this revision should be assigned. O means — assign all.
+                  type: integer
+                  format: int32
+                objectRef:
+                  description: ObjectRef defines the resource that this ServerlessService is responsible for making "serverless".
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  x-kubernetes-map-type: atomic
+                protocolType:
+                  description: The application-layer protocol. Matches `RevisionProtocolType` set on the owning pa/revision. serving imports networking, so just use string.
+                  type: string
+            status:
+              description: 'Status is the current state of the ServerlessService. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
+                privateServiceName:
+                  description: PrivateServiceName holds the name of a core K8s Service resource that load balances over the user service pods backing this Revision.
+                  type: string
+                serviceName:
+                  description: ServiceName holds the name of a core K8s Service resource that load balances over the pods backing this Revision (activator or revision).
+                  type: string
       additionalPrinterColumns:
         - name: Mode
           type: string
@@ -2366,6 +3015,7 @@ spec:
     shortNames:
       - sks
   scope: Namespaced
+
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -2382,14 +3032,14 @@ spec:
 # limitations under the License.
 
 # Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: services.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -2476,6 +3126,10 @@ spec:
                       required:
                         - containers
                       properties:
+                        affinity:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         automountServiceAccountToken:
                           description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                           type: boolean
@@ -2491,12 +3145,12 @@ spec:
                             type: object
                             properties:
                               args:
-                                description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                 type: array
                                 items:
                                   type: string
                               command:
-                                description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                 type: array
                                 items:
                                   type: string
@@ -2534,6 +3188,17 @@ spec:
                                             optional:
                                               description: Specify whether the ConfigMap or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           description: Selects a key of a secret in the pod's namespace
                                           type: object
@@ -2549,7 +3214,7 @@ spec:
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
                                               type: boolean
-                                      x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                               envFrom:
                                 description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                 type: array
@@ -2567,6 +3232,7 @@ spec:
                                         optional:
                                           description: Specify whether the ConfigMap must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
@@ -2580,8 +3246,9 @@ spec:
                                         optional:
                                           description: Specify whether the Secret must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                               image:
-                                description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                                description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                 type: string
                               imagePullPolicy:
                                 description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -2591,7 +3258,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -2629,10 +3296,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -2646,13 +3318,18 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: TCPSocket specifies an action involving a TCP port.
                                     type: object
                                     properties:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -2661,7 +3338,7 @@ spec:
                                 description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                 type: string
                               ports:
-                                description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                                description: List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
                                 type: array
                                 items:
                                   description: ContainerPort represents a network port in a single container.
@@ -2680,7 +3357,6 @@ spec:
                                       description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                       type: string
                                       default: TCP
-                                  x-kubernetes-preserve-unknown-fields: true
                                 x-kubernetes-list-map-keys:
                                   - containerPort
                                   - protocol
@@ -2690,7 +3366,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -2728,10 +3404,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -2745,13 +3426,18 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: TCPSocket specifies an action involving a TCP port.
                                     type: object
                                     properties:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -2782,25 +3468,39 @@ spec:
                                 description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                 type: object
                                 properties:
+                                  allowPrivilegeEscalation:
+                                    description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.'
+                                    type: boolean
                                   capabilities:
-                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                                     type: object
                                     properties:
+                                      add:
+                                        description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
                                       drop:
                                         description: Removed capabilities
                                         type: array
                                         items:
                                           description: Capability represent POSIX capabilities type
                                           type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   readOnlyRootFilesystem:
-                                    description: Whether this container has a read-only root filesystem. Default is false.
+                                    description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
-                                  runAsUser:
-                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
-                                x-kubernetes-preserve-unknown-fields: true
+                                  runAsNonRoot:
+                                    description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string
@@ -2832,12 +3532,29 @@ spec:
                               workingDir:
                                 description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                        dnsConfig:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        dnsPolicy:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                          type: string
                         enableServiceLinks:
-                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
                           type: boolean
+                        hostAliases:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        idleTimeoutSeconds:
+                          description: IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed to stay open while not receiving any bytes from the user's application. If unspecified, a system default will be provided.
+                          type: integer
+                          format: int64
                         imagePullSecrets:
-                          description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                          description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                           type: array
                           items:
                             description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
@@ -2846,13 +3563,60 @@ spec:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
+                            x-kubernetes-map-type: atomic
+                        initContainers:
+                          description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        nodeSelector:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          x-kubernetes-map-type: atomic
+                        priorityClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        responseStartTimeoutSeconds:
+                          description: ResponseStartTimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin sending any network traffic.
+                          type: integer
+                          format: int64
+                        runtimeClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        schedulerName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        securityContext:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         serviceAccountName:
                           description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                           type: string
                         timeoutSeconds:
-                          description: TimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (send network traffic). If unspecified, a system default will be provided.
+                          description: TimeoutSeconds is the maximum duration in seconds that the request instance is allowed to respond to a request. If unspecified, a system default will be provided.
                           type: integer
                           format: int64
+                        tolerations:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        topologySpreadConstraints:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         volumes:
                           description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                           type: array
@@ -2863,15 +3627,15 @@ spec:
                               - name
                             properties:
                               configMap:
-                                description: ConfigMap represents a configMap that should populate this volume
+                                description: configMap represents a configMap that should populate this volume
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                     type: integer
                                     format: int32
                                   items:
-                                    description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                    description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                     type: array
                                     items:
                                       description: Maps a string key to a path within a volume.
@@ -2881,45 +3645,54 @@ spec:
                                         - path
                                       properties:
                                         key:
-                                          description: The key to project.
+                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                           type: integer
                                           format: int32
                                         path:
-                                          description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                           type: string
                                   name:
                                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its keys must be defined
+                                    description: optional specify whether the ConfigMap or its keys must be defined
                                     type: boolean
+                                x-kubernetes-map-type: atomic
+                              emptyDir:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               name:
-                                description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
+                              persistentVolumeClaim:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               projected:
-                                description: Items for all in one resources secrets, configmaps, and downward API
+                                description: projected items for all in one resources secrets, configmaps, and downward API
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                    description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                     type: integer
                                     format: int32
                                   sources:
-                                    description: list of volume projections
+                                    description: sources is the list of volume projections
                                     type: array
                                     items:
                                       description: Projection that may be projected along with other supported volume types
                                       type: object
                                       properties:
                                         configMap:
-                                          description: information about the configMap data to project
+                                          description: configMap information about the configMap data to project
                                           type: object
                                           properties:
                                             items:
-                                              description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                              description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                               type: array
                                               items:
                                                 description: Maps a string key to a path within a volume.
@@ -2929,27 +3702,28 @@ spec:
                                                   - path
                                                 properties:
                                                   key:
-                                                    description: The key to project.
+                                                    description: key is the key to project.
                                                     type: string
                                                   mode:
-                                                    description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                    description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                     type: integer
                                                     format: int32
                                                   path:
-                                                    description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                    description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                     type: string
                                             name:
                                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap or its keys must be defined
+                                              description: optional specify whether the ConfigMap or its keys must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         secret:
-                                          description: information about the secret data to project
+                                          description: secret information about the secret data to project
                                           type: object
                                           properties:
                                             items:
-                                              description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                              description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                               type: array
                                               items:
                                                 description: Maps a string key to a path within a volume.
@@ -2959,47 +3733,48 @@ spec:
                                                   - path
                                                 properties:
                                                   key:
-                                                    description: The key to project.
+                                                    description: key is the key to project.
                                                     type: string
                                                   mode:
-                                                    description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                    description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                     type: integer
                                                     format: int32
                                                   path:
-                                                    description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                    description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                     type: string
                                             name:
                                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret or its key must be defined
+                                              description: optional field specify whether the Secret or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         serviceAccountToken:
-                                          description: information about the serviceAccountToken data to project
+                                          description: serviceAccountToken is information about the serviceAccountToken data to project
                                           type: object
                                           required:
                                             - path
                                           properties:
                                             audience:
-                                              description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                              description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                               type: string
                                             expirationSeconds:
-                                              description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                              description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                               type: integer
                                               format: int64
                                             path:
-                                              description: Path is the path relative to the mount point of the file to project the token into.
+                                              description: path is the path relative to the mount point of the file to project the token into.
                                               type: string
                               secret:
-                                description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                     type: integer
                                     format: int32
                                   items:
-                                    description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                    description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                     type: array
                                     items:
                                       description: Maps a string key to a path within a volume.
@@ -3009,23 +3784,21 @@ spec:
                                         - path
                                       properties:
                                         key:
-                                          description: The key to project.
+                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                           type: integer
                                           format: int32
                                         path:
-                                          description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                           type: string
                                   optional:
-                                    description: Specify whether the Secret or its keys must be defined
+                                    description: optional field specify whether the Secret or its keys must be defined
                                     type: boolean
                                   secretName:
-                                    description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
-                            x-kubernetes-preserve-unknown-fields: true
-                      x-kubernetes-preserve-unknown-fields: true
                 traffic:
                   description: Traffic specifies how to distribute traffic over a collection of revisions and configurations.
                   type: array
@@ -3040,7 +3813,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:
@@ -3080,7 +3853,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -3120,7 +3892,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:
@@ -3135,6 +3907,7 @@ spec:
                 url:
                   description: URL holds the url that will distribute traffic over the provided traffic targets. It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}
                   type: string
+
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -3149,13 +3922,14 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: images.caching.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.5"
     knative.dev/crd-install: "true"
 spec:
   group: caching.internal.knative.dev
@@ -3166,8 +3940,6 @@ spec:
     categories:
       - knative-internal
       - caching
-    shortNames:
-      - img
   scope: Namespaced
   versions:
     - name: v1alpha1
@@ -3177,13 +3949,84 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: Image is a Knative abstraction that encapsulates the interface by which Knative components express a desire to have a particular image cached.
           type: object
-          # this is a work around so we don't need to flush out the
-          # schema for each version at this time
-          #
-          # see issue: https://github.com/knative/serving/issues/912
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec holds the desired state of the Image (from the client).
+              type: object
+              required:
+                - image
+              properties:
+                image:
+                  description: Image is the name of the container image url to cache across the cluster.
+                  type: string
+                imagePullSecrets:
+                  description: ImagePullSecrets contains the names of the Kubernetes Secrets containing login information used by the Pods which will run this container.
+                  type: array
+                  items:
+                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                    type: object
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    x-kubernetes-map-type: atomic
+                serviceAccountName:
+                  description: 'ServiceAccountName is the name of the Kubernetes ServiceAccount as which the Pods will run this container.  This is potentially used to authenticate the image pull if the service account has attached pull secrets.  For more information: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account'
+                  type: string
+            status:
+              description: Status communicates the observed state of the Image (from the controller).
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
       additionalPrinterColumns:
         - name: Image
           type: string
           jsonPath: .spec.image
+
+---

--- a/kubeflow/common/knative/kustomization.yaml
+++ b/kubeflow/common/knative/kustomization.yaml
@@ -9,8 +9,8 @@ resources:
   #
   # knative YAML: https://knative.dev/docs/install/yaml-install/serving/serving-installation-files/
   # Reference issue: https://github.com/knative/serving/issues/9945
-- ./knative-1-2-5/serving-core.yaml
-- ./knative-1-2-5/net-istio.yaml
+- ./knative-1-8-5/serving-core.yaml
+- ./knative-1-8-5/net-istio.yaml
 patches:
 - path: patches/namespace-patch.yaml
 transformers:


### PR DESCRIPTION
Previous upgrade: [KNative 1.2](https://github.com/GoogleCloudPlatform/kubeflow-distribution/pull/373/)

- Upgraded `serving` to 1.8.5
- Upgraded `net-istio` to 1.8.3
- [x] Tested on GKE 1.23

Full testing on GKE 1.24 or 1.25 will be done once all components will be upgraded.

I chose `1.8.5` over `1.8.1` as the latest patches [included](https://github.com/knative/serving/releases) numerous vulnerability fixes.