### PR TITLE
Upgrade ASM to 1.16.2-2. Closes #406

### DIFF
--- a/kubeflow/asm/Makefile
+++ b/kubeflow/asm/Makefile
@@ -10,8 +10,8 @@
 # The part before colon symbol should be used for ASM_PACKAGE_VERSION.
 # The part after colon symbol should be used for ASMCLI_SCRIPT_VERSION.
 SHELL := /bin/bash
-ASM_PACKAGE_VERSION=1.14.1-asm.3+config6
-ASMCLI_SCRIPT_VERSION=asmcli_1.14.1-asm.3-config6
+ASM_PACKAGE_VERSION=1.16.2-asm.2+config1
+ASMCLI_SCRIPT_VERSION=asmcli_1.16.2-asm.2-config1
 
 # The name of the context for your Kubeflow cluster
 PACKAGE_DIR?=$(shell pwd)/..

--- a/kubeflow/env.sh
+++ b/kubeflow/env.sh
@@ -52,4 +52,4 @@ export REGION=us-central1
 # Preferred zone of Cloud SQL. Note, ZONE should be in REGION.
 export ZONE=us-central1-c
 # Anthos Service Mesh version label
-export ASM_LABEL=asm-1141-3
+export ASM_LABEL=asm-1162-2


### PR DESCRIPTION
Previous upgrade: [ASM 1.13](https://github.com/GoogleCloudPlatform/kubeflow-distribution/pull/369)

- Upgraded ASM to `1.16.2-2`
- [x] Tested on GKE `1.23` with `istio-1-14` (`kubeflow/manifests @ 1.6.1`)
- [x] Tested on GKE `1.23` with `istio-1-16` (`kubeflow/manifests @ 1.7.0-rc.1`)

Full testing on GKE 1.24 or 1.25 will be done once all components will be upgraded.

I am still using `istio-1-14` manifests from the upstream. They will be upgraded once we switch to the 1.7 tag of `kubeflow/manifest`. Both options are fully-functional on GKE `1.23`.

**Note:** merge after #409 and #410