### PR TITLE
Upgrade the upstream manifest to v1.7.0. Closes #407. Closes #412.

### DIFF
--- a/kubeflow/contrib/kserve/Makefile
+++ b/kubeflow/contrib/kserve/Makefile
@@ -10,9 +10,17 @@ KFCTXT=$(NAME)
 .PHONY: apply
 apply: hydrate
 	# Apply App kserve
+	# To resolve https://github.com/kubeflow/gcp-blueprints/issues/384,
+	# we apply runtime manifests after the corresponding CRDs become available
+	# 1. Move runtime manifests into a separate subdirectory
+	mkdir $(build_dir)/runtimes
+	mv $(build_dir)/serving*clusterservingruntime* $(build_dir)/runtimes/
+	# 2. Apply the remaining manifests
 	kubectl --context=$(KFCTXT) apply -f $(build_dir)
-	# Wait until CRDs become available or exit in 30s
+	# 3. Wait until CRDs become available or exit in 30s
 	kubectl wait --for condition=established --timeout=30s crd/clusterservingruntimes.serving.kserve.io
+	# 4. Apply runtime manifests
+	kubectl --context=$(KFCTXT) apply -f $(build_dir)/runtimes
 	# Patch knative configmap
 	kubectl --context=$(KFCTXT) patch cm config-domain --namespace knative-serving --type merge -p '{"data":{"$(NAME).endpoints.$(PROJECT).cloud.goog": ""}}'
 

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -16,7 +16,7 @@
 
 set -ex
 
-export KUBEFLOW_MANIFESTS_VERSION=v1.7.0-rc.2
+export KUBEFLOW_MANIFESTS_VERSION=v1.7.0
 export KUBEFLOW_MANIFESTS_REPO=https://github.com/kubeflow/manifests.git
 export KUBEFLOW_PIPELINES_VERSION=2.0.0-alpha.7
 export KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git


### PR DESCRIPTION
- Changes the upstream manifests to v1.7.0
- [x] Tested on GKE 1.24
- [x] Tested on GKE 1.25
- [x] Tested on GKE 1.26
