### PR TITLE
remove metadata.clusterName entirely from cluster.yaml

### DIFF
--- a/kubeflow/common/cluster/upstream/cluster.yaml
+++ b/kubeflow/common/cluster/upstream/cluster.yaml
@@ -17,7 +17,6 @@
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerCluster
 metadata:
-  clusterName: "PROJECT/LOCATION/KUBEFLOW-NAME" # kpt-set: ${gcloud.core.project}/${location}/${name}
   labels:
     mesh_id: "proj-PROJECT_NUMBER" # kpt-set: proj-${gcloud.project.projectNumber}
   name: KUBEFLOW-NAME # kpt-set: ${name}


### PR DESCRIPTION
This line is just causing problems in the GCP deployment. It is no longer needed in this release at all. Removing it:

clusterName: "PROJECT/LOCATION/KUBEFLOW-NAME" # kpt-set: ${gcloud.core.project}/${location}/${name}