### PR TITLE
Remove clusterName from nodepool.yaml

### DIFF
--- a/kubeflow/common/cluster/upstream/nodepool.yaml
+++ b/kubeflow/common/cluster/upstream/nodepool.yaml
@@ -15,7 +15,6 @@
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerNodePool
 metadata:
-  clusterName: "PROJECT/LOCATION/KUBEFLOW-NAME" # kpt-set: ${gcloud.core.project}/${location}/${name}
   name: KUBEFLOW-NAME-cpu-pool-v1 # kpt-set: ${name}-cpu-pool-v1
 spec:
   initialNodeCount: 2


### PR DESCRIPTION
The clusterName is no longer required here and just causes errors when trying to deploy Kubeflow on GCP.  Remove this line:

```
clusterName: "PROJECT/LOCATION/KUBEFLOW-NAME" # kpt-set: ${gcloud.core.project}/${location}/${name}
```