### PR TITLE
Fix SA and add machine type to ContainerCluster. Closes #432.

### DIFF
--- a/kubeflow/common/cnrm/cluster-patch.yaml
+++ b/kubeflow/common/cnrm/cluster-patch.yaml
@@ -27,3 +27,5 @@ spec:
   # Add any fields here to override default cluster spec
   # Refer to https://cloud.google.com/config-connector/docs/reference/resource-docs/container/containercluster
   # for detailed fields and documentation.
+  # nodeConfig:
+  #  machineType: n1-standard-8

--- a/kubeflow/common/cnrm/nodepool-example.yaml
+++ b/kubeflow/common/cnrm/nodepool-example.yaml
@@ -36,7 +36,7 @@ spec:
     metadata:
       disable-legacy-endpoints: "true"
     serviceAccountRef:
-      name: KUBEFLOW-NAME-vm # kpt-set: ${name}-vm    
+      name: KUBEFLOW-NAME-vm # kpt-set: ${name}-vm
     workloadMetadataConfig:
       nodeMetadata: GKE_METADATA_SERVER
   clusterRef:

--- a/kubeflow/common/cnrm/nodepool-example.yaml
+++ b/kubeflow/common/cnrm/nodepool-example.yaml
@@ -36,7 +36,7 @@ spec:
     metadata:
       disable-legacy-endpoints: "true"
     serviceAccountRef:
-      name: KUBEFLOW-NAME-vm@PROJECT.iam.gserviceaccount.com # kpt-set: ${name}-vm@${gcloud.core.project}.iam.gserviceaccount.com
+      name: KUBEFLOW-NAME-vm # kpt-set: ${name}-vm    
     workloadMetadataConfig:
       nodeMetadata: GKE_METADATA_SERVER
   clusterRef:


### PR DESCRIPTION
Changes:
- Fixed SA format `ContainerNodePool`
- Added a sample `spec.nodeConfig.machineType` for `ContainerCluster` to avoid confusion